### PR TITLE
Disable goldenview and switch to NetRw

### DIFF
--- a/config/nvim/init.vim
+++ b/config/nvim/init.vim
@@ -234,7 +234,7 @@ nnoremap <leader>thl :set hlsearch!<CR>
 
 " close buffer with leader-q
 " and safe & close buffer with leader-wq
-nnoremap <leader>q :bd<CR>
+nnoremap <leader>q :Bdelete<CR>
 nnoremap <leader>wq :w<CR>:bd<CR>
 
 " Tab through open buffers
@@ -336,9 +336,6 @@ augroup vimrcEx
 
   " set text_width for git buffers
   autocmd FileType gitcommit setlocal textwidth=70
-
-  " make q exit netrw
-  autocmd FileType netrw nmap Q <C-^>
 augroup END
 " }}}
 " ==============================================================================
@@ -408,8 +405,6 @@ endfunction
 " terminal settings {{{
 " ==============================================================================
   tnoremap <leader><ESC> <C-\><C-n>
-  command! -nargs=* T terminal
-  au BufEnter * if &buftype == 'terminal' | :startinsert | endif
 " }}}
 " ==============================================================================
 

--- a/config/nvim/plugin_configuration.vim
+++ b/config/nvim/plugin_configuration.vim
@@ -91,6 +91,18 @@ endif
 " ------------------------------------------------------------------------------
 
 " ------------------------------------------------------------------------------
+" tpope/vim-vinegar {{{
+" ------------------------------------------------------------------------------
+if has_key(g:plugs, 'vim-vinegar')
+  let g:netrw_keepdir=0 " fixes issue when copying or moving files in netrw
+  no <silent> <leader>fe :Explore<CR>
+  no <silent> <leader>wv :Sexplore!<CR>:AirlineRefresh<CR>
+  no <silent> <leader>ws :Sexplore<CR>:AirlineRefresh<CR>
+endif
+" }}}
+" ------------------------------------------------------------------------------
+
+" ------------------------------------------------------------------------------
 " vim-ruby/vim-ruby {{{
 " ------------------------------------------------------------------------------
 if has_key(g:plugs, 'vim-ruby')
@@ -215,6 +227,7 @@ if has_key(g:plugs, 'GoldenView.Vim')
       endfunction
     " }}}
 
+      "TODO: currently unused
       function! MaximiseCurrentWindow()
         call GoldenView#ToggleAutoResize()
         exec ":MaximizerToggle"
@@ -224,11 +237,12 @@ if has_key(g:plugs, 'GoldenView.Vim')
       " 1. quickly switch current window with the main pane and toggle back
       nmap <silent> <leader>wm <Plug>GoldenViewSwitchMain
       nmap <silent> <leader>wt <Plug>GoldenViewSwitchToggle
-      nmap <silent> <leader>wz :call MaximiseCurrentWindow()<cr>
+      nmap <silent> <leader>wz :MaximizerToggle<cr>
 
       " 2. manipulate splits
       nmap <leader>wt <C-W>T
-      nmap <leader>wd :q<CR>
+      nmap <leader>wd :Bdelete!<CR>
+      nmap <leader>wc :q<CR>
 
       " 3. toggle auto resize
       nmap <silent> <leader>tg :ToggleGoldenViewAutoResize<CR>
@@ -978,20 +992,21 @@ endif
 " ------------------------------------------------------------------------------
 if has_key(g:plugs, 'vim-tmux-navigator')
   let g:tmux_navigator_no_mappings = 1
-  nnoremap <silent> <leader>wh :TmuxNavigateLeft<cr>:AirlineRefresh<cr>
-  nnoremap <silent> <leader>wj :TmuxNavigateDown<cr>:AirlineRefresh<cr>
-  nnoremap <silent> <leader>wk :TmuxNavigateUp<cr>:AirlineRefresh<cr>
-  nnoremap <silent> <leader>wl :TmuxNavigateRight<cr>:AirlineRefresh<cr>
-  nnoremap <silent> <leader>wp :TmuxNavigatePrevious<cr>:AirlineRefresh<cr>
 
-  nnoremap <silent> <leader>wv :vs<cr>:AirlineRefresh<cr>
-  nnoremap <silent> <leader>ws :split<cr>:AirlineRefresh<cr>
+  " Fix in neovim where c-h doesn't work :sadpanda:
+  nnoremap <silent> <BS> :TmuxNavigateLeft<cr>:AirlineRefresh<cr>
 
-  tnoremap <silent> <leader>wh <C-\><C-n>:TmuxNavigateLeft<cr><C-\><C-n>:AirlineRefresh<cr>
-  tnoremap <silent> <leader>wj <C-\><C-n>:TmuxNavigateDown<cr><C-\><C-n>:AirlineRefresh<cr>
-  tnoremap <silent> <leader>wk <C-\><C-n>:TmuxNavigateUp<cr><C-\><C-n>:AirlineRefresh<cr>
-  tnoremap <silent> <leader>wl <C-\><C-n>:TmuxNavigateRight<cr><C-\><C-n>:AirlineRefresh<cr>
-  tnoremap <silent> <leader>wp <C-\><C-n>:TmuxNavigatePrevious<cr><C-\><C-n>:AirlineRefresh<cr>
+  nnoremap <silent> <c-h> :TmuxNavigateLeft<cr>:AirlineRefresh<cr>
+  nnoremap <silent> <c-j> :TmuxNavigateDown<cr>:AirlineRefresh<cr>
+  nnoremap <silent> <c-k> :TmuxNavigateUp<cr>:AirlineRefresh<cr>
+  nnoremap <silent> <c-l> :TmuxNavigateRight<cr>:AirlineRefresh<cr>
+  nnoremap <silent> <c-p> :TmuxNavigatePrevious<cr>:AirlineRefresh<cr>
+
+  tnoremap <silent> <c-h> <C-\><C-n>:TmuxNavigateLeft<cr><C-\><C-n>:AirlineRefresh<cr>
+  tnoremap <silent> <c-j> <C-\><C-n>:TmuxNavigateDown<cr><C-\><C-n>:AirlineRefresh<cr>
+  tnoremap <silent> <c-k> <C-\><C-n>:TmuxNavigateUp<cr><C-\><C-n>:AirlineRefresh<cr>
+  tnoremap <silent> <c-l> <C-\><C-n>:TmuxNavigateRight<cr><C-\><C-n>:AirlineRefresh<cr>
+  tnoremap <silent> <c-p> <C-\><C-n>:TmuxNavigatePrevious<cr><C-\><C-n>:AirlineRefresh<cr>
 endif
 " }}}
 " ------------------------------------------------------------------------------

--- a/config/nvim/plugins.vim
+++ b/config/nvim/plugins.vim
@@ -83,7 +83,8 @@ endif
 " ------------------------------------------------------------------------------
   Plug 'justinmk/vim-sneak' " diagonal movements using S + 2 charaters
   Plug 'junegunn/fzf.vim' | Plug 'junegunn/fzf', { 'dir': '~/.fzf', 'do': './install --all' }
-  Plug 'dangerzone/ranger.vim' | Plug 'moll/vim-bbye' " add ranger as file browser
+  " Plug 'dangerzone/ranger.vim' " add ranger as file browser
+  Plug 'moll/vim-bbye' " add nice buffer deleting
   Plug 'airblade/vim-rooter' " change vim root to vcs root when editing a file
   Plug 'mhinz/vim-signify' " Adds signs in the gutter to indicate vcs changes
   Plug 'christoomey/vim-tmux-navigator' " easy navigation between tmux and vim splits

--- a/tmux.conf
+++ b/tmux.conf
@@ -55,16 +55,6 @@ bind e new-window -n '~/.tmux.conf' "zsh -c '\${EDITOR:-nvim} ~/.tmux.conf && tm
 
 # ── Pane settings ─────────────────────────────────────────────────────────────────────────────────
 
-# smart pane switching with awareness of vim splits {{{
-  is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
-      | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
-  bind-key -n C-h if-shell "$is_vim" "send-keys Space wh"  "select-pane -L"
-  bind-key -n C-j if-shell "$is_vim" "send-keys Space wj"  "select-pane -D"
-  bind-key -n C-k if-shell "$is_vim" "send-keys Space wk"  "select-pane -U"
-  bind-key -n C-l if-shell "$is_vim" "send-keys Space wl"  "select-pane -R"
-  bind-key -n C-\ if-shell "$is_vim" "send-keys C-\\" "select-pane -l"
-# }}}
-
 # Pane resizing {{{
   bind-key -r H resize-pane -L "5"
   bind-key -r L resize-pane -R "5"
@@ -144,5 +134,6 @@ set-option remain-on-exit on # keep new-window 'terminal command' open after the
     tmux-plugins/tmux-resurrect     \
     tmux-plugins/tmux-yank          \
     tmux-plugins/tmux-copycat       \
+    christoomey/vim-tmux-navigator  \
   '
 # }}}


### PR DESCRIPTION
This PR simplifies the Tmux <-> vim navigation and makes sure that new splits contain NetRw Explore of the current directory.