### PR TITLE
Fix quoting in rmlink.sh

### DIFF
--- a/scripts/rmlink.sh
+++ b/scripts/rmlink.sh
@@ -2,7 +2,7 @@
 
 # Removes the original file of a symbolic link
 rmlink() {
-  rm "$(greadlink -f $1)"
+  rm "$(greadlink -f "$1")"
   unlink "$1"
 }
 


### PR DESCRIPTION
## Summary
- quote argument passed to `greadlink`
- ensure all parameter expansions in `rmlink.sh` are quoted

## Testing
- `bash -n scripts/rmlink.sh`