### PR TITLE
Fix rcrc exclude entry

### DIFF
--- a/rcrc
+++ b/rcrc
@@ -1,3 +1,3 @@
 COPY_ALWAYS="ssh/*"
-EXCLUDES="_assets _snowblocks bin .* README.md *:node_modules *:history *:cache Brewfile Brewfile.lock.json Yarnfile Cargofile"
+EXCLUDES="_assets _snowblocks bin .* README.md *:node_modules *:history *:cache Brewfile Brewfile.lock.json Yarnfile CargoFile"
 UNDOTTED="rubocop.yml tern-config"


### PR DESCRIPTION
## Summary
- correct CargoFile entry in rcrc's exclude list

## Testing
- `rcup` *(fails: command not found)*