### PR TITLE
Fix rmlink.sh readlink fallback

### DIFF
--- a/scripts/rmlink.sh
+++ b/scripts/rmlink.sh
@@ -2,7 +2,9 @@
 
 # Removes the original file of a symbolic link
 rmlink() {
-  rm "$(greadlink -f "$1")"
+  local readlink_cmd
+  readlink_cmd=$(command -v greadlink || command -v readlink)
+  rm "$($readlink_cmd -f "$1")"
   unlink "$1"
 }
 


### PR DESCRIPTION
## Summary
- fall back to `readlink` if `greadlink` is missing

## Testing
- `bash -n scripts/rmlink.sh`
- `apt-get update` *(fails: unable to connect to proxy)*