### PR TITLE
Remove redundant local vim statements

### DIFF
--- a/config/nvim/lua/plugins/autocomplete.lua
+++ b/config/nvim/lua/plugins/autocomplete.lua
@@ -1,4 +1,3 @@
-local vim = vim or {}
 local cmp = require('cmp')
 local lspkind = require('lspkind')
 

--- a/config/nvim/lua/plugins/git.lua
+++ b/config/nvim/lua/plugins/git.lua
@@ -1,4 +1,3 @@
-local vim = vim or {}
 local Util = require('util')
 local nmap = Util.nmap
 

--- a/config/nvim/lua/plugins/kommentary.lua
+++ b/config/nvim/lua/plugins/kommentary.lua
@@ -1,4 +1,3 @@
-local vim = vim or {}
 
 vim.g.kommentary_create_default_mappings = false
 

--- a/config/nvim/lua/plugins/nvim-lspconfig.lua
+++ b/config/nvim/lua/plugins/nvim-lspconfig.lua
@@ -1,4 +1,3 @@
-local vim = vim or {}
 local lspconfig = require('lspconfig')
 local configs = require("lspconfig.configs")
 local util = require("lspconfig.util")

--- a/config/nvim/lua/plugins/nvim-treesitter.lua
+++ b/config/nvim/lua/plugins/nvim-treesitter.lua
@@ -1,4 +1,3 @@
-local vim = vim or {}
 
 --[[ require'nvim-treesitter.configs'.setup {
   -- A list of parser names, or "all" (the five listed parsers should always be installed)

--- a/config/nvim/lua/plugins/oil-nvim.lua
+++ b/config/nvim/lua/plugins/oil-nvim.lua
@@ -1,4 +1,3 @@
-local vim = vim or {}
 
 require("oil").setup()
 

--- a/config/nvim/lua/plugins/telescope.lua
+++ b/config/nvim/lua/plugins/telescope.lua
@@ -1,5 +1,4 @@
 -- Telescope requires
-local vim = vim or {}
 local builtin = require('telescope.builtin')
 local actions = require('telescope.actions')
 local action_state = require('telescope.actions.state')

--- a/config/nvim/lua/plugins/testing.lua
+++ b/config/nvim/lua/plugins/testing.lua
@@ -1,4 +1,3 @@
-local vim = vim or {}
 
 require("neotest").setup({
   adapters = {


### PR DESCRIPTION
## Summary
- clean up plugin configuration files
- remove `local vim = vim or {}` from each plugin

## Testing
- `scripts/spec --help` *(fails: File does not exist)*