### PR TITLE
Enable Lua module loader in Neovim config

### DIFF
--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -1,4 +1,5 @@
 local vim = vim or {}
+vim.loader.enable()
 local Util = require('util')
 local General = require('general')
 


### PR DESCRIPTION
## Summary
- activate `vim.loader.enable()` before loading other Lua modules

## Testing
- `nvim --headless +quit` *(fails: command not found)*