### PR TITLE
Fix nvim options usage and mapping descriptions

### DIFF
--- a/config/nvim/after/ftplugin/diff.lua
+++ b/config/nvim/after/ftplugin/diff.lua
@@ -1,22 +1,21 @@
 local vim = vim or {}
-local wo = vim.wo
 local Util = require('util')
 local nnoremap = Util.nnoremap
 
-wo.foldenable = true
-wo.foldlevel = 0
-wo.foldnestmax = 0
+vim.opt_local.foldenable = true
+vim.opt_local.foldlevel = 0
+vim.opt_local.foldnestmax = 0
 
-wo.list = false
+vim.opt_local.list = false
 
-wo.cursorcolumn = false
-wo.cursorline = false
-wo.conceallevel = 0
-wo.colorcolumn = '0'
+vim.opt_local.cursorcolumn = false
+vim.opt_local.cursorline = false
+vim.opt_local.conceallevel = 0
+vim.opt_local.colorcolumn = '0'
 
 -- NOTE: Ensures that :q and :x work with neovim-remote
 -- https://github.com/mhinz/neovim-remote#typical-use-cases
-vim.bo.bufhidden = 'delete'
+vim.opt_local.bufhidden = 'delete'
 
 vim.cmd(':normal zv')
 

--- a/config/nvim/after/ftplugin/git.lua
+++ b/config/nvim/after/ftplugin/git.lua
@@ -1,8 +1,7 @@
 local vim = vim or {}
-local wo = vim.wo
 
-wo.list = false
-wo.cursorcolumn = false
-wo.cursorline = false
-wo.conceallevel = 0
-wo.colorcolumn = '0'
+vim.opt_local.list = false
+vim.opt_local.cursorcolumn = false
+vim.opt_local.cursorline = false
+vim.opt_local.conceallevel = 0
+vim.opt_local.colorcolumn = '0'

--- a/config/nvim/after/ftplugin/gitcommit.lua
+++ b/config/nvim/after/ftplugin/gitcommit.lua
@@ -1,6 +1,6 @@
-vim.wo.spell = true
-vim.bo.textwidth = 70
+vim.opt_local.spell = true
+vim.opt_local.textwidth = 70
 
 -- NOTE: Ensures that :q and :x work with neovim-remote
 -- https://github.com/mhinz/neovim-remote#typical-use-cases
-vim.bo.bufhidden = 'delete'
+vim.opt_local.bufhidden = 'delete'

--- a/config/nvim/after/ftplugin/gitconfig.lua
+++ b/config/nvim/after/ftplugin/gitconfig.lua
@@ -1,6 +1,6 @@
-vim.wo.spell = true
-vim.bo.textwidth = 70
+vim.opt_local.spell = true
+vim.opt_local.textwidth = 70
 
 -- NOTE: Ensures that :q and :x work with neovim-remote
 -- https://github.com/mhinz/neovim-remote#typical-use-cases
-vim.bo.bufhidden = 'delete'
+vim.opt_local.bufhidden = 'delete'

--- a/config/nvim/after/ftplugin/gitrebase.lua
+++ b/config/nvim/after/ftplugin/gitrebase.lua
@@ -1,6 +1,6 @@
-vim.wo.spell = true
-vim.bo.textwidth = 70
+vim.opt_local.spell = true
+vim.opt_local.textwidth = 70
 
 -- NOTE: Ensures that :q and :x work with neovim-remote
 -- https://github.com/mhinz/neovim-remote#typical-use-cases
-vim.bo.bufhidden = 'delete'
+vim.opt_local.bufhidden = 'delete'

--- a/config/nvim/after/ftplugin/go.lua
+++ b/config/nvim/after/ftplugin/go.lua
@@ -1,9 +1,9 @@
 local vim = vim or {}
 
 -- vim.bo.tabstop = 2
-vim.bo.tabstop = 4
-vim.bo.shiftwidth = 4
-vim.bo.softtabstop = 4
-vim.bo.expandtab = 0
+vim.opt_local.tabstop = 4
+vim.opt_local.shiftwidth = 4
+vim.opt_local.softtabstop = 4
+vim.opt_local.expandtab = 0
 
 -- vim.o.list = true

--- a/config/nvim/after/ftplugin/help.lua
+++ b/config/nvim/after/ftplugin/help.lua
@@ -7,13 +7,13 @@ local nmap = Util.nmap
 -- * https://github.com/dahu/vim-help
 -- * https://github.com/rafi/vim-config/blob/master/ftplugin/help.vim
 
-vim.wo.spell = false
+vim.opt_local.spell = false
 
-vim.bo.bufhidden = ''
-vim.bo.iskeyword = vim.bo.iskeyword .. ",:,#,-"
+vim.opt_local.bufhidden = ''
+vim.opt_local.iskeyword = vim.bo.iskeyword .. ",:,#,-"
 
-vim.wo.cursorline = false
-vim.wo.colorcolumn = '0'
+vim.opt_local.cursorline = false
+vim.opt_local.colorcolumn = '0'
 
 -- Jump to links with o and L
 nmap('o', [[<C-]>]], {}, true)

--- a/config/nvim/after/ftplugin/html.lua
+++ b/config/nvim/after/ftplugin/html.lua
@@ -1,1 +1,1 @@
-vim.wo.spell = true
+vim.opt_local.spell = true

--- a/config/nvim/after/ftplugin/markdown.lua
+++ b/config/nvim/after/ftplugin/markdown.lua
@@ -2,10 +2,10 @@ local vim = vim or {}
 local Util = require('util')
 local imap = Util.imap
 
-vim.wo.spell = true
+vim.opt_local.spell = true
 
 -- setlocal omnifunc=htmlcomplete#CompleteTags
-vim.bo.complete = vim.bo.complete .. ',kspell'
+vim.opt_local.complete = vim.bo.complete .. ',kspell'
 
 -- imap('<c-l>' [[<Esc>[s1z=`]a]], {}, true)
 

--- a/config/nvim/after/ftplugin/patch.lua
+++ b/config/nvim/after/ftplugin/patch.lua
@@ -1,16 +1,15 @@
 local vim = vim or {}
-local wo = vim.wo
 
-wo.foldenable = true
+vim.opt_local.foldenable = true
 
 -- Autofold nothing by default
-wo.foldlevel = 0
+vim.opt_local.foldlevel = 0
 
 -- Only fold outer functions
-wo.foldnestmax = 0
+vim.opt_local.foldnestmax = 0
 
-wo.list = false
-wo.cursorcolumn = false
-wo.cursorline = false
-wo.conceallevel = 0
-wo.colorcolumn = '0'
+vim.opt_local.list = false
+vim.opt_local.cursorcolumn = false
+vim.opt_local.cursorline = false
+vim.opt_local.conceallevel = 0
+vim.opt_local.colorcolumn = '0'

--- a/config/nvim/after/ftplugin/ruby.lua
+++ b/config/nvim/after/ftplugin/ruby.lua
@@ -1,7 +1,7 @@
 local vim = vim or {}
 
-vim.wo.number = true
-vim.wo.relativenumber = true
+vim.opt_local.number = true
+vim.opt_local.relativenumber = true
 
 -- TODO: evaluate if these abbreviations are still used
 --[[ " NOTE: poor man's snippets

--- a/config/nvim/after/ftplugin/sql.lua
+++ b/config/nvim/after/ftplugin/sql.lua
@@ -1,2 +1,2 @@
-vim.wo.foldenable = false
-vim.wo.foldmethod = 'manual'
+vim.opt_local.foldenable = false
+vim.opt_local.foldmethod = 'manual'

--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -137,7 +137,11 @@ nnoremap('N', [[Nzz:lua require('general').hl_next(100)<cr>]])
 -- Define the function to execute a macro over a visual selection
 
 -- Map '@' in visual mode to the function
-vim.keymap.set('x', '@', [[:<C-u>lua require('general').ExecuteMacroOverVisualRange()<CR>]], { noremap = true, silent = true })
+vim.keymap.set('x', '@', [[:<C-u>lua require('general').ExecuteMacroOverVisualRange()<CR>]], {
+  noremap = true,
+  silent = true,
+  desc = 'Run macro over visual selection'
+})
 
 -- Define the Bufmacro command
 vim.api.nvim_create_user_command('Bufmacro', function()
@@ -272,7 +276,11 @@ nnoremap('<leader>fed', ':e $MYVIMRC<CR>')
 nnoremap('<leader>feR', ':luafile $MYVIMRC<CR>')
 
 -- Save file with sudo
-vim.keymap.set('c', 'w!!', 'w !sudo tee % > /dev/null', { noremap = true, silent = false })
+vim.keymap.set('c', 'w!!', 'w !sudo tee % > /dev/null', {
+  noremap = true,
+  silent = false,
+  desc = 'Write with sudo'
+})
 
 -- Copy current file path + line number to system clipboard
 nnoremap('<leader>fC', [[:let @+=expand("%") . ":" . line(".")<CR>]])

--- a/config/nvim/lua/plugins/kommentary.lua
+++ b/config/nvim/lua/plugins/kommentary.lua
@@ -1,6 +1,6 @@
 
 vim.g.kommentary_create_default_mappings = false
 
-vim.keymap.set("n", "gcc", "<Plug>kommentary_line_default")
-vim.keymap.set("n", "gc", "<Plug>kommentary_motion_default")
-vim.keymap.set("v", "gc", "<Plug>kommentary_visual_default<C-c>")
+vim.keymap.set("n", "gcc", "<Plug>kommentary_line_default", { desc = 'Toggle comment line' })
+vim.keymap.set("n", "gc", "<Plug>kommentary_motion_default", { desc = 'Toggle comment motion' })
+vim.keymap.set("v", "gc", "<Plug>kommentary_visual_default<C-c>", { desc = 'Toggle comment selection' })

--- a/config/nvim/lua/plugins/telescope.lua
+++ b/config/nvim/lua/plugins/telescope.lua
@@ -98,33 +98,69 @@ require('telescope').setup{
 
 -- Files bindings {{{
 -- Open general Telescope picker
-vim.keymap.set('n', '<leader>m', "<cmd>lua require('telescope.builtin').marks()<CR>", { noremap = true, silent = true })
+vim.keymap.set('n', '<leader>m', "<cmd>lua require('telescope.builtin').marks()<CR>", {
+  noremap = true,
+  silent = true,
+  desc = 'List marks'
+})
 
 -- Open general Telescope picker
-vim.keymap.set('n', '<leader>tl', "<cmd>Telescope<CR>", { noremap = true, silent = true })
+vim.keymap.set('n', '<leader>tl', "<cmd>Telescope<CR>", {
+  noremap = true,
+  silent = true,
+  desc = 'Open Telescope'
+})
 
 -- Find files in the current project (similar to FZF's project_files)
-vim.keymap.set('n', '<leader>pf', "<cmd>lua require('telescope.builtin').git_files()<CR>", { noremap = true, silent = true })
+vim.keymap.set('n', '<leader>pf', "<cmd>lua require('telescope.builtin').git_files()<CR>", {
+  noremap = true,
+  silent = true,
+  desc = 'Project files'
+})
 
 -- Live grep in the project
-vim.keymap.set('n', '<leader>p/', "<cmd>lua require('telescope.builtin').live_grep()<CR>", { noremap = true, silent = true })
+vim.keymap.set('n', '<leader>p/', "<cmd>lua require('telescope.builtin').live_grep()<CR>", {
+  noremap = true,
+  silent = true,
+  desc = 'Grep project'
+})
 
 -- Find files using the file browser
-vim.keymap.set('n', '<leader>ff', "<cmd>lua require('telescope.builtin').find_files()<CR>", { noremap = true, silent = true })
+vim.keymap.set('n', '<leader>ff', "<cmd>lua require('telescope.builtin').find_files()<CR>", {
+  noremap = true,
+  silent = true,
+  desc = 'Find files'
+})
 -- }}}
 
 -- Buffer bindings {{{
 -- List open buffers
-vim.keymap.set('n', '<leader>bb', "<cmd>lua require('telescope.builtin').buffers()<CR>", { noremap = true, silent = true })
-vim.keymap.set('n', 'gb', "<cmd>lua require('telescope.builtin').buffers()<CR>", { noremap = true, silent = true })
+vim.keymap.set('n', '<leader>bb', "<cmd>lua require('telescope.builtin').buffers()<CR>", {
+  noremap = true,
+  silent = true,
+  desc = 'List buffers'
+})
+vim.keymap.set('n', 'gb', "<cmd>lua require('telescope.builtin').buffers()<CR>", {
+  noremap = true,
+  silent = true,
+  desc = 'List buffers'
+})
 -- }}}
 
 -- Git bindings {{{
 -- List files changed in current branch
-vim.keymap.set('n', '<leader>gF', "<cmd>lua require('telescope.builtin').git_files()<CR>", { noremap = true, silent = true })
+vim.keymap.set('n', '<leader>gF', "<cmd>lua require('telescope.builtin').git_files()<CR>", {
+  noremap = true,
+  silent = true,
+  desc = 'Git files'
+})
 
 -- List git diffs for current file
-vim.keymap.set('n', '<leader>gf', "<cmd>lua require('telescope.builtin').git_status()<CR>", { noremap = true, silent = true })
+vim.keymap.set('n', '<leader>gf', "<cmd>lua require('telescope.builtin').git_status()<CR>", {
+  noremap = true,
+  silent = true,
+  desc = 'Git status'
+})
 -- }}}
 
 -- Load Telescope extensions

--- a/config/nvim/lua/plugins/vim-bbye.lua
+++ b/config/nvim/lua/plugins/vim-bbye.lua
@@ -1,15 +1,15 @@
 local map = vim.keymap.set
 
-map('n', '<leader>wc', ':q<cr>', {})
-map('n', '<leader>bd', ':Bdelete<CR>', {})
+map('n', '<leader>wc', ':q<cr>', { desc = 'Close window' })
+map('n', '<leader>bd', ':Bdelete<CR>', { desc = 'Delete buffer' })
 
-map('n', '<leader>tC', ':tabnew<CR>', {})
-map('n', '<leader>tc', ':tabclose<CR>', {})
-map('n', '<leader>tp', ':tabprevious<CR>', {})
-map('n', '<leader>tn', ':tabnext<CR>', {})
+map('n', '<leader>tC', ':tabnew<CR>', { desc = 'New tab' })
+map('n', '<leader>tc', ':tabclose<CR>', { desc = 'Close tab' })
+map('n', '<leader>tp', ':tabprevious<CR>', { desc = 'Previous tab' })
+map('n', '<leader>tn', ':tabnext<CR>', { desc = 'Next tab' })
 
 -- Delete all hidden buffers
-map('n', '<leader>bo', ':DeleteHiddenBuffers<CR>', { noremap = true, silent = true })
+map('n', '<leader>bo', ':DeleteHiddenBuffers<CR>', { noremap = true, silent = true, desc = 'Delete hidden buffers' })
 
 -- Delete all buffers, but keep windows open
-map('n', '<leader>bw', ':bufdo :Bdelete<CR>', { noremap = true, silent = true })
+map('n', '<leader>bw', ':bufdo :Bdelete<CR>', { noremap = true, silent = true, desc = 'Wipe all buffers' })

--- a/config/nvim/lua/plugins/vim-maximizer.lua
+++ b/config/nvim/lua/plugins/vim-maximizer.lua
@@ -3,4 +3,4 @@ local map = vim.keymap.set
 vim.g.maximizer_set_default_mapping = 0
 vim.g.maximizer_restore_on_winleave = 1
 
-map('n', '<leader>wz', ':MaximizerToggle<CR>', { silent = true })
+map('n', '<leader>wz', ':MaximizerToggle<CR>', { silent = true, desc = 'Toggle window maximizer' })


### PR DESCRIPTION
## Summary
- use `vim.opt_local` for buffer/window option configuration
- provide descriptions for Telescope, kommentary, vim-bbye and other key mappings
- describe macros and privileged write keymaps

## Testing
- `true`