### PR TITLE
Support private zshenv local overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ bin/pretty
 
 # dotenv environment variable files
 .env*
+.zshenv.local
 
 # fzf / RG
 .git

--- a/zshenv
+++ b/zshenv
@@ -11,14 +11,6 @@ export TZ_LIST='Europe/Amsterdam,America/New_York,America/Los_Angeles'
 export SKIP_WAIT=1
 export LINT_STAGED=1
 export PULL_LOCK=1
-export POSTGRES_USERNAME='alexanderjeurissenlocal'
-export POSTGRES_PASSWORD='hunter3'
-export TAILWIND_MODE='watch'
-export HACKERONE_ON_DOCKER=true
-
-export CLAUDE_CODE_USE_BEDROCK=1
-export ANTHROPIC_MODEL="us.anthropic.claude-3-7-sonnet-20250219-v1:0"
-export ANTHROPIC_SMALL_FAST_MODEL="us.anthropic.claude-3-5-haiku-20241022-v1:0"
 
 # export LIBRARY_PATH="/opt/homebrew/opt/gcc/lib/gcc/$(gcc -dumpversion)/"
 # export LD_LIBRARY_PATH="/opt/homebrew/opt/gcc/lib/gcc/$(gcc -dumpversion)/"
@@ -98,3 +90,5 @@ export FZF_CTRL_T_COMMAND='rg --files'
   export LS_COLORS="$LS_COLORS:*.BAK=01;33:*.old=01;33:*.OLD=01;33:*.org_archive=01;33:*.off=01;33:*.OFF=01;33:*.dist=01;33:*.DIST=01;33:*.orig=01;33:*.ORIG=01;33"
   export LS_COLORS="$LS_COLORS:*.swp=01;33:*.swo=01;33:*.v=01;33:*.gpg=34:*.gpg=34:*.pgp=34:*.asc=34:*.3des=34:*.aes=34:*.enc=34:*.sqlite=34"
 # }}}
+
+[[ -f ~/.zshenv.local ]] && source ~/.zshenv.local


### PR DESCRIPTION
## Summary
- ignore `~/.zshenv.local`
- move private variables out of `zshenv`
- source `~/.zshenv.local` when present

## Testing
- `git status --ignored --short | grep zshenv.local`