### PR TITLE
Fix PATH duplicates in zprofile

### DIFF
--- a/zprofile
+++ b/zprofile
@@ -36,6 +36,8 @@ export PATH="$PATH:/usr/sbin"
 export PATH="$PATH:/sbin"
 # }}}
 
+typeset -U path PATH
+
 
 # Java settings
 # export JAVA_HOME="/usr/libexec/java_home"


### PR DESCRIPTION
## Summary
- deduplicate `$PATH` using `typeset -U`

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`