### PR TITLE
Use cached HOMEBREW_PREFIX for zsh plugins

### DIFF
--- a/zshenv
+++ b/zshenv
@@ -3,6 +3,7 @@ export EDITOR='nvim'
 export HSANDBOX_EDITOR='nvim'
 
 export HOMEBREW_PREFIX="/opt/homebrew" # lookup using (brew --prefix)
+# Export early so startup scripts can use the cached value without invoking brew
 
 # Misc env variables
 export TZ_LIST='Europe/Amsterdam,America/New_York,America/Los_Angeles'

--- a/zshrc
+++ b/zshrc
@@ -60,10 +60,10 @@ fi
 
 # Plugins {{{
   if command -v brew >/dev/null; then
-    plugin_dir="$(brew --prefix)/share/zsh-autosuggestions"
+    plugin_dir="$HOMEBREW_PREFIX/share/zsh-autosuggestions"
     [[ -f $plugin_dir/zsh-autosuggestions.zsh ]] && source $plugin_dir/zsh-autosuggestions.zsh
     # TODO: zsh-syntax-highlighting significantly slows down the shell
-    # source $(brew --prefix)/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+    # source $HOMEBREW_PREFIX/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
   fi
 # }}}
 


### PR DESCRIPTION
## Summary
- use `$HOMEBREW_PREFIX` in `zshrc` for plugin paths
- document why the variable is set early in `zshenv`

## Testing
- `git status --short`