### PR TITLE
Configure tmux-256color

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -13,7 +13,7 @@
 set-option -sg escape-time 0 # change the escape time in tmux to zero, improves vim responsiveness
 set-option -g history-limit 50000 # Increase scrollback history
 
-set -g default-terminal "screen-256color"
+set -g default-terminal "tmux-256color"
 set -g default-shell ${SHELL}
 
 set -g default-command ${SHELL}
@@ -30,7 +30,6 @@ set -g pane-base-index 1 # start with pane 1
 setw -g mode-keys vi # enable vim mode
 
 # Undercurl
-set -g default-terminal "${TERM}"
 set -as terminal-overrides ',*:Smulx=\E[4::%p1%dm'  # undercurl support
 set -as terminal-overrides ',*:Setulc=\E[58::2::%p1%{65536}%/%d::%p1%{256}%/%{255}%&%d::%p1%{255}%&%d%;m'  # underscore colours - needs tmux-3.0
 


### PR DESCRIPTION
## Summary
- use `tmux-256color` as the default terminal in tmux
- compile the provided terminfo entries

## Testing
- `./scripts/install-terminfo.sh`