### PR TITLE
Add manual TPM install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ scripts/install-terminfo.sh
 This installs the entries into `~/.terminfo` so that tools like tmux can use
 them.
 
+### Tmux plugins
+
+Clone the [Tmux Plugin Manager](https://github.com/tmux-plugins/tpm) and
+install the configured plugins by running:
+
+```sh
+scripts/install-tmux-plugins.sh
+```
+
+Run this once after linking `tmux.conf`.
+
 ## License
 
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/scripts/install-tmux-plugins.sh
+++ b/scripts/install-tmux-plugins.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+TPM_DIR="$HOME/.tmux/plugins/tpm"
+
+if [ ! -d "$TPM_DIR" ]; then
+  git clone https://github.com/tmux-plugins/tpm "$TPM_DIR"
+fi
+
+"$TPM_DIR/bin/install_plugins"

--- a/tmux.conf
+++ b/tmux.conf
@@ -145,11 +145,6 @@ set -as terminal-overrides ',*:Setulc=\E[58::2::%p1%{65536}%/%d::%p1%{256}%/%{25
   set -g @plugin "tmux-plugins/tmux-pain-control"
   set -g @plugin "christoomey/vim-tmux-navigator"
   set -g @plugin "tmux-plugins/tmux-sessionist"
-
-  # Check if tmux plugin manager is installed, otherwise clone it.
-  if "test ! -d ~/.tmux/plugins/tpm" \
-     "run 'git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm && ~/.tmux/plugins/tpm/bin/install_plugins'"
-
   # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
   run '~/.tmux/plugins/tpm/tpm'
 # }}}


### PR DESCRIPTION
## Summary
- remove auto-clone logic from `tmux.conf`
- add `scripts/install-tmux-plugins.sh` to manually install TPM and plugins
- document the new script in the README

## Testing
- `bash -n scripts/install-tmux-plugins.sh`
- `shellcheck scripts/install-tmux-plugins.sh` *(fails: command not found)*