### PR TITLE
Comment out verbose options in scdaemon.conf

### DIFF
--- a/gnupg/scdaemon.conf
+++ b/gnupg/scdaemon.conf
@@ -1,5 +1,5 @@
 reader-port Yubico Yubi
-debug-all
-debug-level guru
-disable-ccid
-log-file /tmp/scd.log
+# debug-all
+# debug-level guru
+# disable-ccid
+# log-file /tmp/scd.log


### PR DESCRIPTION
## Summary
- disable debugging and logging options in `gnupg/scdaemon.conf`

## Testing
- `git status --short`