### PR TITLE
Add cached Homebrew env script

### DIFF
--- a/scripts/generate-brew-env.sh
+++ b/scripts/generate-brew-env.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${HOMEBREW_PREFIX:=/opt/homebrew}"
+mkdir -p "$HOME/.cache"
+"$HOMEBREW_PREFIX/bin/brew" shellenv > "$HOME/.cache/brew_env.zsh"
+

--- a/zprofile
+++ b/zprofile
@@ -1,4 +1,10 @@
-eval "$(/opt/homebrew/bin/brew shellenv)"
+BREW_ENV="$HOME/.cache/brew_env.zsh"
+if [ -r "$BREW_ENV" ]; then
+  source "$BREW_ENV"
+else
+  ~/.dotfiles/scripts/generate-brew-env.sh
+  source "$BREW_ENV"
+fi
 
 # Added by OrbStack: command-line tools and integration
 source ~/.orbstack/shell/init.zsh 2>/dev/null || :


### PR DESCRIPTION
## Summary
- generate Homebrew shell environment into `~/.cache/brew_env.zsh`
- source cached environment from `zprofile`

## Testing
- `scripts/generate-brew-env.sh` *(fails: `/opt/homebrew/bin/brew` not found)*