### PR TITLE
Configure zsh completions

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -19,6 +19,13 @@ bindkey "^E" forward-char
   setopt hist_verify
 # }}}
 
+# Initialize completion system
+autoload -Uz compinit
+compinit -d ~/.cache/zcompdump-$ZSH_VERSION
+if [[ -f ~/.cache/zcompdump-$ZSH_VERSION ]]; then
+  zcompile ~/.cache/zcompdump-$ZSH_VERSION
+fi
+
 # Disables greeting
 unsetopt correct_all
 


### PR DESCRIPTION
## Summary
- set up `compinit` after the history settings
- create cached completion dump and compile it

## Testing
- `git status --short`
