### PR TITLE
Support compiled zsh startup files

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ scripts/install-tmux-plugins.sh
 
 Run this once after linking `tmux.conf`.
 
+### Compiling Zsh files
+
+Run `scripts/compile-zsh` whenever you modify `zsh_prompt`, `zsh_aliases` or
+`zsh_keybindings` to regenerate their `.zwc` files. The compiled versions will
+be loaded automatically if present.
+
 ## License
 
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/scripts/compile-zsh
+++ b/scripts/compile-zsh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+for file in zsh_prompt zsh_aliases zsh_keybindings; do
+  if [ -f "$ROOT/$file" ]; then
+    zsh -fc "zcompile $ROOT/$file"
+  fi
+done

--- a/zshrc
+++ b/zshrc
@@ -73,9 +73,21 @@ fi
   bindkey -v
 # }}
 
-source ~/.zsh_aliases
-builtin source ~/.zsh_prompt
-source ~/.zsh_keybindings
+if [[ -f ~/.zsh_aliases.zwc ]]; then
+  source ~/.zsh_aliases.zwc
+else
+  source ~/.zsh_aliases
+fi
+if [[ -f ~/.zsh_prompt.zwc ]]; then
+  builtin source ~/.zsh_prompt.zwc
+else
+  builtin source ~/.zsh_prompt
+fi
+if [[ -f ~/.zsh_keybindings.zwc ]]; then
+  source ~/.zsh_keybindings.zwc
+else
+  source ~/.zsh_keybindings
+fi
 # vim: foldmethod=marker:sw=2:foldlevel=10
 #
 


### PR DESCRIPTION
## Summary
- load precompiled `.zwc` files for zsh aliases, prompt, and keybindings
- add `scripts/compile-zsh` helper
- document how to regenerate `.zwc` files

## Testing
- `scripts/compile-zsh` *(fails: `zsh: command not found`)*