### PR TITLE
Optimize git status check in zsh prompt

### DIFF
--- a/zsh_prompt
+++ b/zsh_prompt
@@ -40,7 +40,7 @@ _generate_prompt() {
 
   # VCS info
   if [[ -n $working_tree ]]; then
-    if git diff-index --quiet HEAD -- 2>/dev/null; then
+    if [[ ${git_dirty:-0} -eq 0 ]]; then
       prompt_content+=$(_segment 'default' 'default' "${vcs_info_msg_0_}" $SSH_CONNECTION)
     else
       prompt_content+=$(_segment 'default' 'default' "${vcs_info_msg_0_}*" $SSH_CONNECTION)
@@ -78,8 +78,14 @@ _prompt_buffer_empty() {
 _update_vcs_info() {
   if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     vcs_info
+    if git status --porcelain=2 --untracked-files=no --ignore-submodules | grep -q .; then
+      git_dirty=1
+    else
+      git_dirty=0
+    fi
   else
     unset vcs_info_msg_0_ vcs_info_msg_1_ vcs_info_msg_2_
+    unset git_dirty
   fi
 }
 


### PR DESCRIPTION
## Summary
- avoid heavy git index operations when rendering the zsh prompt
- cache repository status in `_update_vcs_info`

## Testing
- `shellcheck --version` *(fails: command not found)*