### PR TITLE
Add workspace engine + cmux-spawn-work to scripts/ (on PATH via ~/.scripts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ In summary my work environment consists of:
 ### Using rcm
 
 1. Install `rcm` using your package manager, e.g. `brew install rcm`.
-2. Clone this repository into `~/Development/personal/workspace/dotfiles`.
-3. Run `rcup -v -d ~/Development/personal/workspace/dotfiles` to symlink all
+2. Clone this repository into `~/Development/personal/hub/dotfiles`.
+3. Run `rcup -v -d ~/Development/personal/hub/dotfiles` to symlink all
    managed files from this repository location. The included `rcrc` file
    controls which files are linked.
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ In summary my work environment consists of:
 ### Using rcm
 
 1. Install `rcm` using your package manager, e.g. `brew install rcm`.
-2. Clone this repository into `~/Development/personal/hub/dotfiles`.
-3. Run `rcup -v -d ~/Development/personal/hub/dotfiles` to symlink all
+2. Clone this repository into `~/Development/personal/hub/modules/dotfiles`.
+3. Run `rcup -v -d ~/Development/personal/hub/modules/dotfiles` to symlink all
    managed files from this repository location. The included `rcrc` file
    controls which files are linked.
 

--- a/claude/WORKSPACE.md
+++ b/claude/WORKSPACE.md
@@ -8,7 +8,7 @@ here names a specific repository or organization — the engine discovers all of
 Two terms carry the load (and used to collide — they're now distinct):
 
 - **hub** = the top-level checkout — the stable integration view, containing `modules/` (submodules
-  on their integration branches) and `worktrees/`. It stays open as the home base. The git repo it's
+  on their integration branches) and `workspaces/`. It stays open as the home base. The git repo it's
   a checkout of is the **hub repo**.
 - **workspace** = the per-issue, isolated environment for one unit of work — *materialized* as git
   *worktrees* (a top-level worktree of the hub + nested submodule worktrees) plus its cmux workspace.
@@ -53,7 +53,7 @@ never touches the hub checkout, so that's rare.
 
 Parallel work on multiple issues happens in **isolated per-issue workspaces**, not by switching
 branches in the hub's submodule checkouts. Each issue gets a "mini-workspace": a git worktree of *the
-hub repo* at `worktrees/<ISSUE>/` (carrying `CLAUDE.md`/`AGENTS.md`, `.claude/`, `.cmux/`, `docs/`, …),
+hub repo* at `workspaces/<ISSUE>/` (carrying `CLAUDE.md`/`AGENTS.md`, `.claude/`, `.cmux/`, `docs/`, …),
 with a git worktree of each in-scope submodule nested inside it under `modules/<repo>` on the issue's
 feature branch (mirroring the hub's `modules/` layout). Submodule object stores are shared (no
 re-clone), and a cmux workspace cwd's into it — so the Claude instance sees a complete, isolated
@@ -63,7 +63,7 @@ environment.
 <hub>/                          PRIMARY — the hub, a stable integration view
 ├─ modules/                     submodules on their integration branches
 │  └─ repo-a/  repo-b/  …
-└─ worktrees/
+└─ workspaces/
    ├─ WORKSPACES.md             tracked reconstruction manifest (the checkouts are gitignored)
    └─ <ISSUE>/                  a per-issue workspace (worktree of the hub repo)
       ├─ CLAUDE.md .claude/ …    came free with the top-level worktree
@@ -97,9 +97,9 @@ slash commands orchestrate the tracker, scope confirmation, the hub-repo commits
 pins), and cmux spawning. The commands are global (`~/.claude/commands/`, symlinked from
 `dotfiles/claude/commands/`), so every hub shares one copy.
 
-### The manifest — `worktrees/WORKSPACES.md`
+### The manifest — `workspaces/WORKSPACES.md`
 
-Tracked, while the per-issue checkouts are gitignored (`worktrees/*/`). One row per active workspace
+Tracked, while the per-issue checkouts are gitignored (`workspaces/*/`). One row per active workspace
 (issue, title, repos, branch, opened). It's a **reconstruction recipe**: on a fresh clone, each row
 is enough to rebuild the workspace from the pushed feature branches — which is exactly why
 `/workspace-sync`'s push matters. `/workspace` and `/teardown` maintain it; the row is committed as
@@ -107,7 +107,7 @@ standing housekeeping.
 
 ### Memory & history
 
-Because a workspace cwd's to `worktrees/<ISSUE>/`, Claude keys it as a separate project (separate
+Because a workspace cwd's to `workspaces/<ISSUE>/`, Claude keys it as a separate project (separate
 memory + history). `/workspace` symlinks that project's `memory/` → the canonical hub memory, so
 **facts are shared** while **history stays isolated** per issue.
 
@@ -119,13 +119,13 @@ per-issue workspace — created by `/workspace`. The hub itself stays open as th
 ### What `/workspace` spawns
 
 `/workspace <ISSUE>` calls `cmux-spawn-work`, which creates a cmux workspace **cwd'd to**
-`worktrees/<ISSUE>/` (the isolated mini-workspace), split into **two panes** — **Claude Code** on the
+`workspaces/<ISSUE>/` (the isolated mini-workspace), split into **two panes** — **Claude Code** on the
 left and a **terminal** on the right — and tagged with a **distinct color** (the `/workspace` command
 picks one not already in use; `cmux-spawn-work` defaults to Blue). It is **idempotent** (re-running
 with the same `--name` returns the existing workspace) and **never steals focus** (`--focus false`).
 
 ```bash
-cmux-spawn-work --name "<ISSUE> · <title>" --cwd "$PWD/worktrees/<ISSUE>"
+cmux-spawn-work --name "<ISSUE> · <title>" --cwd "$PWD/workspaces/<ISSUE>"
 # → workspace=workspace:21 status=created name="<ISSUE> · <title>"
 ```
 

--- a/claude/WORKSPACE.md
+++ b/claude/WORKSPACE.md
@@ -1,21 +1,27 @@
 # Workspace workflow (shared)
 
-This is the host-neutral core of the per-issue worktree workflow, shared across every workspace
-that uses it. Each workspace's own `CLAUDE.md`/`AGENTS.md` imports this file and then adds its
-repo-specific bits (the actual submodules + remotes, integration branches, tracker/forge
-conventions). Nothing here names a specific repository or organization — the
-engine discovers all of that at runtime.
+This is the host-neutral core of the per-issue worktree workflow, shared across every **hub** that
+uses it. Each hub's own `CLAUDE.md`/`AGENTS.md` imports this file and then adds its repo-specific
+bits (the actual submodules + remotes, integration branches, tracker/forge conventions). Nothing
+here names a specific repository or organization — the engine discovers all of that at runtime.
 
-Throughout: **workspace** = the top-level checkout (the stable integration view); **issue** = the
-work identifier a per-issue worktree is keyed on (a tracker issue, a PR/MR, or an ad-hoc slug);
-**PR/MR** = the merge request on whichever forge a submodule lives (GitHub PR, GitLab MR).
+Two terms carry the load (and used to collide — they're now distinct):
+
+- **hub** = the top-level checkout — the stable integration view, containing `modules/` (submodules
+  on their integration branches) and `worktrees/`. It stays open as the home base. The git repo it's
+  a checkout of is the **hub repo**.
+- **workspace** = a per-issue worktree *of the hub* — an isolated mini-environment (the hub-repo
+  worktree + nested submodule worktrees + its cmux workspace) for one unit of work.
+
+Also: **issue** = the work identifier a workspace is keyed on (a tracker issue, a PR/MR, or an
+ad-hoc slug); **PR/MR** = the merge request on whichever forge a submodule lives (GitHub PR, GitLab MR).
 
 ## Repository structure conventions
 
-A workspace is a git repo that groups **git submodules** for the code/content repos under
-`modules/`, plus the tracked worktree manifest. Work tracking and planning live in the issue
-tracker (Linear), not in the repo. Each submodule is configured with `update=none` — treat each as
-an independent git repo:
+The hub is a checkout of a git repo (the *hub repo*) that groups **git submodules** for the
+code/content repos under `modules/`, plus the tracked worktree manifest. Work tracking and planning
+live in the issue tracker (Linear), not in the repo. Each submodule is configured with `update=none`
+— treat each as an independent git repo:
 
 - To make changes: `cd modules/<repo>/ && git checkout <branch> && … && git commit && git push`.
 - Each submodule has its own remote, branches, and history.
@@ -23,124 +29,121 @@ an independent git repo:
 - NEVER run `git submodule update` — it is a no-op by design (`update=none`).
 - Git operations (add, commit, push, checkout) inside a submodule are scoped to that submodule's repo.
 
-The workspace repo may also track supporting assets (e.g. `mockups/`) — commit those from the
-workspace root.
+The hub repo may also track supporting assets (e.g. `mockups/`) — commit those from the hub.
 
 ### Pinning submodule state (auto-pin)
 
-**Always auto-pin immediately after a commit lands in a submodule** in the *main checkout*. As soon
-as you commit (or rebase/reset to a new SHA) in a main-checkout submodule, pin its new SHA in the
-workspace repo:
+**Always auto-pin immediately after a commit lands in a submodule** in the *hub checkout*. As soon as
+you commit (or rebase/reset to a new SHA) in a hub-checkout submodule, pin its new SHA in the hub repo:
 
 ```sh
-git -C "$(workspace root)" add modules/<repo>   # stages the submodule's current SHA as a gitlink
-git -C "$(workspace root)" commit -m "pin <repo> after <description>"
+git -C "$(workspace hub)" add modules/<repo>   # stages the submodule's current SHA as a gitlink
+git -C "$(workspace hub)" commit -m "pin <repo> after <description>"
 ```
 
-Submodule commit → workspace-repo pin, every time. Stage only the gitlink(s) you changed so the
-pin commit stays focused. **In the worktree-focused workflow, pinning is consolidated into
-`/update-modules`** (the single pinning path): feature commits land in per-issue *worktrees* and do
-**not** pin, while the top-level checkout is fast-forwarded to integration-branch tips and pinned
-there. The rule above still governs any *direct* commit you make in a main-checkout submodule, but
-in normal flow feature work never touches the main checkout, so that's rare.
+Submodule commit → hub-repo pin, every time. Stage only the gitlink(s) you changed so the pin commit
+stays focused. **In the worktree-focused workflow, pinning is consolidated into `/update-modules`**
+(the single pinning path): feature commits land in per-issue *workspaces* and do **not** pin, while
+the hub checkout is fast-forwarded to integration-branch tips and pinned there. The rule above still
+governs any *direct* commit you make in a hub-checkout submodule, but in normal flow feature work
+never touches the hub checkout, so that's rare.
 
-## Per-issue worktree workspaces
+## Per-issue workspaces
 
-Parallel work on multiple issues happens in **isolated per-issue worktrees**, not by switching
-branches in the shared submodule checkouts. Each issue gets a "mini-workspace": a git worktree of
-*this workspace repo* at `worktrees/<ISSUE>/` (carrying `CLAUDE.md`/`AGENTS.md`, `.claude/`,
-`.cmux/`, `docs/`, …), with a git worktree of each in-scope submodule nested inside it under
-`modules/<repo>` on the issue's feature branch (mirroring the main checkout's `modules/` layout).
-Submodule object stores are shared (no re-clone), and a cmux workspace cwd's into it — so the
-Claude instance sees a complete, isolated environment.
+Parallel work on multiple issues happens in **isolated per-issue workspaces**, not by switching
+branches in the hub's submodule checkouts. Each issue gets a "mini-workspace": a git worktree of *the
+hub repo* at `worktrees/<ISSUE>/` (carrying `CLAUDE.md`/`AGENTS.md`, `.claude/`, `.cmux/`, `docs/`, …),
+with a git worktree of each in-scope submodule nested inside it under `modules/<repo>` on the issue's
+feature branch (mirroring the hub's `modules/` layout). Submodule object stores are shared (no
+re-clone), and a cmux workspace cwd's into it — so the Claude instance sees a complete, isolated
+environment.
 
 ```
-<workspace>/                    PRIMARY — stable integration view
+<hub>/                          PRIMARY — the hub, a stable integration view
 ├─ modules/                     submodules on their integration branches
 │  └─ repo-a/  repo-b/  …
 └─ worktrees/
    ├─ WORKSPACES.md             tracked reconstruction manifest (the checkouts are gitignored)
-   └─ <ISSUE>/                  a per-issue mini-workspace (worktree of the workspace repo)
-      ├─ CLAUDE.md .claude/ …    came free with the workspace worktree
+   └─ <ISSUE>/                  a per-issue workspace (worktree of the hub repo)
+      ├─ CLAUDE.md .claude/ …    came free with the hub-repo worktree
       └─ modules/
          └─ repo-a/             worktree of repo-a on the feature branch (shared object store)
 ```
 
 ### The integration-branch invariant (load-bearing)
 
-In the top-level checkout, **each submodule sits on its integration branch** (e.g. `main`, or
-`develop`/`master` where a repo uses those). That checkout *is* the per-repo source of truth: every
-command reads "what branch is this submodule on in the workspace?" to decide the integration base.
-Nothing is hardcoded. **Feature work never lives in the main checkout — only in worktrees.**
+In the hub checkout, **each submodule sits on its integration branch** (e.g. `main`, or
+`develop`/`master` where a repo uses those). The hub *is* the per-repo source of truth: every command
+reads "what branch is this submodule on in the hub?" to decide the integration base. Nothing is
+hardcoded. **Feature work never lives in the hub checkout — only in workspaces.**
 `workspace integration-branch <repo>` resolves it and warns when a checkout diverges from its
-`origin/HEAD` default (usually a sign of leaked feature work that wants migrating into a worktree).
+`origin/HEAD` default (usually a sign of leaked feature work that wants migrating into a workspace).
 
 ### The four commands
 
 | Command | What it does |
 |---|---|
-| `/workspace <ISSUE>` | Create the mini-workspace: workspace worktree + submodule worktrees on the feature branch, share memory, record the manifest, spawn a cmux workspace (Claude Code + terminal splits) cwd'd into it. Claude *suggests* repo scope; the user confirms. |
+| `/workspace <ISSUE>` | Create the workspace: a hub-repo worktree + submodule worktrees on the feature branch, share memory, record the manifest, spawn a cmux workspace (Claude Code + terminal splits) cwd'd into it. Claude *suggests* repo scope; the user confirms. |
 | `/workspace-sync [ISSUE]` | **Merge** each submodule's integration branch into the feature branch (never rebase) + push. Auto-resolves mechanical conflicts, asks when ambiguous; auto-targets the workspace it's run from. No force-push. |
-| `/update-modules` | Fast-forward the main checkout's submodules to their integration tips + **pin**. The only pinning path. Run after upstream PRs/MRs merge. |
-| `/teardown <ISSUE>` | Remove the worktrees + drop the manifest row (after a safety check for unsaved work). Keeps feature branches and the cmux workspace. |
+| `/update-modules` | Fast-forward the hub checkout's submodules to their integration tips + **pin**. The only pinning path. Run after upstream PRs/MRs merge. |
+| `/teardown <ISSUE>` | Remove the workspace's worktrees + drop the manifest row (after a safety check for unsaved work). Keeps feature branches and the cmux workspace. |
 
-The engine `workspace` (on PATH, from `dotfiles/scripts/` via `~/.scripts`; shared across
-workspaces and discovering this one's submodules + integration branches from `.gitmodules` and the
-main checkout) does the deterministic git/fs plumbing only — it never commits the workspace repo,
-talks to a tracker, or touches cmux. The slash commands orchestrate the tracker, scope
-confirmation, the workspace-repo commits (manifest rows, pins), and cmux spawning. The commands are
-global (`~/.claude/commands/`, symlinked from `dotfiles/claude/commands/`), so every workspace
-shares one copy.
+The engine `workspace` (on PATH, from `dotfiles/scripts/` via `~/.scripts`; shared across hubs and
+discovering this hub's submodules + integration branches from `.gitmodules` and the hub checkout)
+does the deterministic git/fs plumbing only — it never commits the hub repo, talks to a tracker, or
+touches cmux. (`workspace hub` prints the hub path from anywhere; `$WORKSPACE_HUB` overrides it.) The
+slash commands orchestrate the tracker, scope confirmation, the hub-repo commits (manifest rows,
+pins), and cmux spawning. The commands are global (`~/.claude/commands/`, symlinked from
+`dotfiles/claude/commands/`), so every hub shares one copy.
 
 ### The manifest — `worktrees/WORKSPACES.md`
 
 Tracked, while the per-issue checkouts are gitignored (`worktrees/*/`). One row per active workspace
 (issue, title, repos, branch, opened). It's a **reconstruction recipe**: on a fresh clone, each row
-is enough to rebuild the worktree from the pushed feature branches — which is exactly why
+is enough to rebuild the workspace from the pushed feature branches — which is exactly why
 `/workspace-sync`'s push matters. `/workspace` and `/teardown` maintain it; the row is committed as
 standing housekeeping.
 
 ### Memory & history
 
-Because a per-issue workspace cwd's to `worktrees/<ISSUE>/`, Claude keys it as a separate project
-(separate memory + history). `/workspace` symlinks that project's `memory/` → the canonical
-workspace memory, so **facts are shared** while **history stays isolated** per issue.
+Because a workspace cwd's to `worktrees/<ISSUE>/`, Claude keys it as a separate project (separate
+memory + history). `/workspace` symlinks that project's `memory/` → the canonical hub memory, so
+**facts are shared** while **history stays isolated** per issue.
 
 ## cmux Workflow
 
 cmux is the visual map of in-flight work. Each active issue gets **one cmux workspace** — the
-per-issue worktree — created by `/workspace`. The workspace root stays open as the hub.
+per-issue worktree — created by `/workspace`. The hub itself stays open as the home base.
 
 ### What `/workspace` spawns
 
-`/workspace <ISSUE>` calls `cmux-spawn-work`, which creates a workspace **cwd'd to**
-`worktrees/<ISSUE>/` (the isolated mini-workspace), split into **two panes** — **Claude Code** on
-the left and a **terminal** on the right — and tagged with a **distinct color** (the `/workspace`
-command picks one not already in use; `cmux-spawn-work` defaults to Blue). It is **idempotent**
-(re-running with the same `--name` returns the existing workspace) and **never steals focus**
-(`--focus false`).
+`/workspace <ISSUE>` calls `cmux-spawn-work`, which creates a cmux workspace **cwd'd to**
+`worktrees/<ISSUE>/` (the isolated mini-workspace), split into **two panes** — **Claude Code** on the
+left and a **terminal** on the right — and tagged with a **distinct color** (the `/workspace` command
+picks one not already in use; `cmux-spawn-work` defaults to Blue). It is **idempotent** (re-running
+with the same `--name` returns the existing workspace) and **never steals focus** (`--focus false`).
 
 ```bash
 cmux-spawn-work --name "<ISSUE> · <title>" --cwd "$PWD/worktrees/<ISSUE>"
 # → workspace=workspace:21 status=created name="<ISSUE> · <title>"
 ```
 
-Workspace naming: `<ISSUE-ID> · <title>`. Output is one `key=value` line; capture `workspace=` if
-you need the ref.
+Workspace naming: `<ISSUE-ID> · <title>`. Output is one `key=value` line; capture `workspace=` if you
+need the ref.
 
 ### Rules for agents
 
 - **`/workspace` proposes, never auto-spawns.** It confirms repo scope before creating worktrees or
   the cmux workspace. Skip the spawn if you're already inside the right workspace.
-- **Inside a workspace, submodule paths are `modules/<repo>/…`** — exactly as at the workspace root.
+- **Inside a workspace, submodule paths are `modules/<repo>/…`** — exactly as in the hub.
 - **Never steal focus.** `cmux-spawn-work` passes `--focus false`; don't call `select-workspace`,
   `focus-pane`, or `focus-panel` after spawning.
 - **Never auto-close.** Closing is always the user's decision. `/teardown` removes the *worktrees*
   but leaves the cmux workspace open for the user to close
   (`cmux close-workspace --workspace <ref>`).
 
-Each workspace's `.cmux/cmux.json` defines its own static Command-Palette templates (the home hub,
-and any surface like a mockup previewer). After editing it, run `cmux reload-config`.
+Each hub's `.cmux/cmux.json` defines its own static Command-Palette templates (the hub home base, and
+any surface like a mockup previewer). After editing it, run `cmux reload-config`.
 
 ## Mermaid Diagrams
 

--- a/claude/WORKSPACE.md
+++ b/claude/WORKSPACE.md
@@ -1,0 +1,181 @@
+# Workspace workflow (shared)
+
+This is the host-neutral core of the per-issue worktree workflow, shared across every workspace
+that uses it. Each workspace's own `CLAUDE.md`/`AGENTS.md` imports this file and then adds its
+repo-specific bits (the actual submodules + remotes, integration branches, tracker/forge
+conventions, planning artifacts). Nothing here names a specific repository or organization — the
+engine discovers all of that at runtime.
+
+Throughout: **workspace** = the top-level checkout (the stable integration view); **issue** = the
+work identifier a per-issue worktree is keyed on (a tracker issue, a PR/MR, or an ad-hoc slug);
+**PR/MR** = the merge request on whichever forge a submodule lives (GitHub PR, GitLab MR).
+
+## Repository structure conventions
+
+A workspace is a git repo holding **planning artifacts** alongside **git submodules** for the
+code/content repos. All submodules live under `modules/` and are configured with `update=none` —
+treat each as an independent git repo:
+
+- To make changes: `cd modules/<repo>/ && git checkout <branch> && … && git commit && git push`.
+- Each submodule has its own remote, branches, and history.
+- **Before implementing changes**, ensure the target repo is on a feature branch (create one if needed).
+- NEVER run `git submodule update` — it is a no-op by design (`update=none`).
+- Git operations (add, commit, push, checkout) inside a submodule are scoped to that submodule's repo.
+
+The workspace repo also tracks planning artifacts (e.g. `mockups/`, `docs/`) — commit those from
+the workspace root.
+
+### Pinning submodule state (auto-pin)
+
+**Always auto-pin immediately after a commit lands in a submodule** in the *main checkout*. As soon
+as you commit (or rebase/reset to a new SHA) in a main-checkout submodule, pin its new SHA in the
+workspace repo:
+
+```sh
+git -C "$(workspace root)" add modules/<repo>   # stages the submodule's current SHA as a gitlink
+git -C "$(workspace root)" commit -m "pin <repo> after <description>"
+```
+
+Submodule commit → workspace-repo pin, every time. Stage only the gitlink(s) you changed so the
+pin commit stays focused. **In the worktree-focused workflow, pinning is consolidated into
+`/update-modules`** (the single pinning path): feature commits land in per-issue *worktrees* and do
+**not** pin, while the top-level checkout is fast-forwarded to integration-branch tips and pinned
+there. The rule above still governs any *direct* commit you make in a main-checkout submodule, but
+in normal flow feature work never touches the main checkout, so that's rare.
+
+## Per-issue worktree workspaces
+
+Parallel work on multiple issues happens in **isolated per-issue worktrees**, not by switching
+branches in the shared submodule checkouts. Each issue gets a "mini-workspace": a git worktree of
+*this workspace repo* at `worktrees/<ISSUE>/` (carrying `CLAUDE.md`/`AGENTS.md`, `.claude/`,
+`.cmux/`, `docs/`, …), with a git worktree of each in-scope submodule nested inside it under
+`modules/<repo>` on the issue's feature branch (mirroring the main checkout's `modules/` layout).
+Submodule object stores are shared (no re-clone), and a cmux workspace cwd's into it — so the
+Claude instance sees a complete, isolated environment.
+
+```
+<workspace>/                    PRIMARY — stable integration view
+├─ modules/                     submodules on their integration branches
+│  └─ repo-a/  repo-b/  …
+└─ worktrees/
+   ├─ WORKSPACES.md             tracked reconstruction manifest (the checkouts are gitignored)
+   └─ <ISSUE>/                  a per-issue mini-workspace (worktree of the workspace repo)
+      ├─ CLAUDE.md .claude/ …    came free with the workspace worktree
+      └─ modules/
+         └─ repo-a/             worktree of repo-a on the feature branch (shared object store)
+```
+
+### The integration-branch invariant (load-bearing)
+
+In the top-level checkout, **each submodule sits on its integration branch** (e.g. `main`, or
+`develop`/`master` where a repo uses those). That checkout *is* the per-repo source of truth: every
+command reads "what branch is this submodule on in the workspace?" to decide the integration base.
+Nothing is hardcoded. **Feature work never lives in the main checkout — only in worktrees.**
+`workspace integration-branch <repo>` resolves it and warns when a checkout diverges from its
+`origin/HEAD` default (usually a sign of leaked feature work that wants migrating into a worktree).
+
+### The four commands
+
+| Command | What it does |
+|---|---|
+| `/workspace <ISSUE>` | Create the mini-workspace: workspace worktree + submodule worktrees on the feature branch, share memory, record the manifest, spawn a cmux workspace (Claude Code + terminal splits) cwd'd into it. Claude *suggests* repo scope; the user confirms. |
+| `/workspace-sync [ISSUE]` | **Merge** each submodule's integration branch into the feature branch (never rebase) + push. Auto-resolves mechanical conflicts, asks when ambiguous; auto-targets the workspace it's run from. No force-push. |
+| `/update-modules` | Fast-forward the main checkout's submodules to their integration tips + **pin**. The only pinning path. Run after upstream PRs/MRs merge. |
+| `/teardown <ISSUE>` | Remove the worktrees + drop the manifest row (after a safety check for unsaved work). Keeps feature branches and the cmux workspace. |
+
+The engine `workspace` (on PATH, from `dotfiles/scripts/` via `~/.scripts`; shared across
+workspaces and discovering this one's submodules + integration branches from `.gitmodules` and the
+main checkout) does the deterministic git/fs plumbing only — it never commits the workspace repo,
+talks to a tracker, or touches cmux. The slash commands orchestrate the tracker, scope
+confirmation, the workspace-repo commits (manifest rows, pins), and cmux spawning. The commands are
+global (`~/.claude/commands/`, symlinked from `dotfiles/claude/commands/`), so every workspace
+shares one copy.
+
+### The manifest — `worktrees/WORKSPACES.md`
+
+Tracked, while the per-issue checkouts are gitignored (`worktrees/*/`). One row per active workspace
+(issue, title, repos, branch, opened). It's a **reconstruction recipe**: on a fresh clone, each row
+is enough to rebuild the worktree from the pushed feature branches — which is exactly why
+`/workspace-sync`'s push matters. `/workspace` and `/teardown` maintain it; the row is committed as
+standing housekeeping.
+
+### Memory & history
+
+Because a per-issue workspace cwd's to `worktrees/<ISSUE>/`, Claude keys it as a separate project
+(separate memory + history). `/workspace` symlinks that project's `memory/` → the canonical
+workspace memory, so **facts are shared** while **history stays isolated** per issue.
+
+## cmux Workflow
+
+cmux is the visual map of in-flight work. Each active issue gets **one cmux workspace** — the
+per-issue worktree — created by `/workspace`. The workspace root stays open as the hub.
+
+### What `/workspace` spawns
+
+`/workspace <ISSUE>` calls `cmux-spawn-work`, which creates a workspace **cwd'd to**
+`worktrees/<ISSUE>/` (the isolated mini-workspace), split into **two panes** — **Claude Code** on
+the left and a **terminal** on the right — and tagged with a **distinct color** (the `/workspace`
+command picks one not already in use; `cmux-spawn-work` defaults to Blue). It is **idempotent**
+(re-running with the same `--name` returns the existing workspace) and **never steals focus**
+(`--focus false`).
+
+```bash
+cmux-spawn-work --name "<ISSUE> · <title>" --cwd "$PWD/worktrees/<ISSUE>"
+# → workspace=workspace:21 status=created name="<ISSUE> · <title>"
+```
+
+Workspace naming: `<ISSUE-ID> · <title>`. Output is one `key=value` line; capture `workspace=` if
+you need the ref.
+
+### Rules for agents
+
+- **`/workspace` proposes, never auto-spawns.** It confirms repo scope before creating worktrees or
+  the cmux workspace. Skip the spawn if you're already inside the right workspace.
+- **Inside a workspace, submodule paths are `modules/<repo>/…`** — exactly as at the workspace root.
+- **Never steal focus.** `cmux-spawn-work` passes `--focus false`; don't call `select-workspace`,
+  `focus-pane`, or `focus-panel` after spawning.
+- **Never auto-close.** Closing is always the user's decision. `/teardown` removes the *worktrees*
+  but leaves the cmux workspace open for the user to close
+  (`cmux close-workspace --workspace <ref>`).
+
+Each workspace's `.cmux/cmux.json` defines its own static Command-Palette templates (the home hub,
+and any surface like a mockup previewer). After editing it, run `cmux reload-config`.
+
+## Mermaid Diagrams
+
+When generating Mermaid diagrams, follow these rules:
+
+### Structure
+
+- **Use flowcharts with subgraphs** — prefer `graph TD` / `graph LR` with `subgraph` blocks to
+  organize related nodes. This is the default diagram type for all visualizations.
+- **Never use sequence diagrams** — model actor/service interactions as a flowchart with subgraphs
+  representing each actor/service and edges representing the interactions.
+- **Subgraph naming** — use quoted descriptive labels: `subgraph Core["Main Service"]`. The ID is a
+  short key; the quoted string is the human-readable title.
+- **Internal direction** — set `direction TB` or `direction LR` inside each subgraph.
+- **Direction** — `TD` (top-down) for hierarchical flows, `LR` (left-right) for pipelines/timelines.
+
+### Styling (required)
+
+Every diagram must include explicit styling. Every subgraph must have a `style` declaration with
+`fill`, `stroke`, `stroke-width`, and `color`. Use this semantic palette:
+
+  | Role / meaning        | fill      | stroke    |
+  |-----------------------|-----------|-----------|
+  | Primary / core system | `#f0f4ff` | `#0969da` |
+  | Success / result      | `#f0fff4` | `#1a7f37` |
+  | Secondary / agent     | `#f0f4ff` | `#8250df` |
+  | Warning / gateway     | `#fff8f0` | `#bc4c00` |
+  | Error / deny          | `#ffcdd2` | `#c62828` |
+
+Always set `color:#1f2328` for readable text, and `stroke-width:2px` for primary subgraphs (1px for
+secondary/supporting ones). Nodes representing error states or decision outcomes should get
+individual `style` declarations (e.g., `style Deny fill:#ffcdd2,stroke:#c62828,stroke-width:2px`).
+
+### Rich node content
+
+- **HTML line breaks** — use `<br/>` inside node labels for multi-line content.
+- **Italic annotations** — use `<i>...</i>` for secondary details within node labels.
+- **Edge labels** — describe the action or data being passed (e.g., `-->|"POST /login"|`).
+- **Dashed edges** — use `-.->` for secondary/reference/async flows; solid (`-->`) for the happy path.

--- a/claude/WORKSPACE.md
+++ b/claude/WORKSPACE.md
@@ -10,8 +10,8 @@ Two terms carry the load (and used to collide — they're now distinct):
 - **hub** = the top-level checkout — the stable integration view, containing `modules/` (submodules
   on their integration branches) and `worktrees/`. It stays open as the home base. The git repo it's
   a checkout of is the **hub repo**.
-- **workspace** = the per-issue, isolated environment for one unit of work — *materialized* as a git
-  *worktree* of the hub (the hub-repo worktree + nested submodule worktrees) plus its cmux workspace.
+- **workspace** = the per-issue, isolated environment for one unit of work — *materialized* as git
+  *worktrees* (a top-level worktree of the hub + nested submodule worktrees) plus its cmux workspace.
   ("worktree" is the git mechanism; "workspace" is the thing you work in.)
 
 Also: **issue** = the work identifier a workspace is keyed on (a tracker issue, a PR/MR, or an
@@ -66,7 +66,7 @@ environment.
 └─ worktrees/
    ├─ WORKSPACES.md             tracked reconstruction manifest (the checkouts are gitignored)
    └─ <ISSUE>/                  a per-issue workspace (worktree of the hub repo)
-      ├─ CLAUDE.md .claude/ …    came free with the hub-repo worktree
+      ├─ CLAUDE.md .claude/ …    came free with the top-level worktree
       └─ modules/
          └─ repo-a/             worktree of repo-a on the feature branch (shared object store)
 ```
@@ -84,7 +84,7 @@ hardcoded. **Feature work never lives in the hub checkout — only in workspaces
 
 | Command | What it does |
 |---|---|
-| `/workspace <ISSUE>` | Create the workspace: a hub-repo worktree + submodule worktrees on the feature branch, share memory, record the manifest, spawn a cmux workspace (Claude Code + terminal splits) cwd'd into it. Claude *suggests* repo scope; the user confirms. |
+| `/workspace <ISSUE>` | Create the workspace: a top-level worktree + submodule worktrees on the feature branch, share memory, record the manifest, spawn a cmux workspace (Claude Code + terminal splits) cwd'd into it. Claude *suggests* repo scope; the user confirms. |
 | `/workspace-sync [ISSUE]` | **Merge** each submodule's integration branch into the feature branch (never rebase) + push. Auto-resolves mechanical conflicts, asks when ambiguous; auto-targets the workspace it's run from. No force-push. |
 | `/update-modules` | Fast-forward the hub checkout's submodules to their integration tips + **pin**. The only pinning path. Run after upstream PRs/MRs merge. |
 | `/teardown <ISSUE>` | Remove the workspace's worktrees + drop the manifest row (after a safety check for unsaved work). Keeps feature branches and the cmux workspace. |

--- a/claude/WORKSPACE.md
+++ b/claude/WORKSPACE.md
@@ -3,7 +3,7 @@
 This is the host-neutral core of the per-issue worktree workflow, shared across every workspace
 that uses it. Each workspace's own `CLAUDE.md`/`AGENTS.md` imports this file and then adds its
 repo-specific bits (the actual submodules + remotes, integration branches, tracker/forge
-conventions, planning artifacts). Nothing here names a specific repository or organization — the
+conventions). Nothing here names a specific repository or organization — the
 engine discovers all of that at runtime.
 
 Throughout: **workspace** = the top-level checkout (the stable integration view); **issue** = the
@@ -12,9 +12,10 @@ work identifier a per-issue worktree is keyed on (a tracker issue, a PR/MR, or a
 
 ## Repository structure conventions
 
-A workspace is a git repo holding **planning artifacts** alongside **git submodules** for the
-code/content repos. All submodules live under `modules/` and are configured with `update=none` —
-treat each as an independent git repo:
+A workspace is a git repo that groups **git submodules** for the code/content repos under
+`modules/`, plus the tracked worktree manifest. Work tracking and planning live in the issue
+tracker (Linear), not in the repo. Each submodule is configured with `update=none` — treat each as
+an independent git repo:
 
 - To make changes: `cd modules/<repo>/ && git checkout <branch> && … && git commit && git push`.
 - Each submodule has its own remote, branches, and history.
@@ -22,8 +23,8 @@ treat each as an independent git repo:
 - NEVER run `git submodule update` — it is a no-op by design (`update=none`).
 - Git operations (add, commit, push, checkout) inside a submodule are scoped to that submodule's repo.
 
-The workspace repo also tracks planning artifacts (e.g. `mockups/`, `docs/`) — commit those from
-the workspace root.
+The workspace repo may also track supporting assets (e.g. `mockups/`) — commit those from the
+workspace root.
 
 ### Pinning submodule state (auto-pin)
 

--- a/claude/WORKSPACE.md
+++ b/claude/WORKSPACE.md
@@ -136,7 +136,7 @@ need the ref.
 
 - **`/workspace` proposes, never auto-spawns.** It confirms repo scope before creating worktrees or
   the cmux workspace. Skip the spawn if you're already inside the right workspace.
-- **Inside a workspace, submodule paths are `modules/<repo>/…`** — exactly as in the hub.
+- **Inside a workspace, submodule paths are `modules/<repo>/…`** — exactly as at the hub root.
 - **Never steal focus.** `cmux-spawn-work` passes `--focus false`; don't call `select-workspace`,
   `focus-pane`, or `focus-panel` after spawning.
 - **Never auto-close.** Closing is always the user's decision. `/teardown` removes the *worktrees*

--- a/claude/WORKSPACE.md
+++ b/claude/WORKSPACE.md
@@ -1,6 +1,6 @@
 # Workspace workflow (shared)
 
-This is the host-neutral core of the per-issue worktree workflow, shared across every **hub** that
+This is the host-neutral core of the per-issue workspace workflow, shared across every **hub** that
 uses it. Each hub's own `CLAUDE.md`/`AGENTS.md` imports this file and then adds its repo-specific
 bits (the actual submodules + remotes, integration branches, tracker/forge conventions). Nothing
 here names a specific repository or organization — the engine discovers all of that at runtime.
@@ -10,8 +10,9 @@ Two terms carry the load (and used to collide — they're now distinct):
 - **hub** = the top-level checkout — the stable integration view, containing `modules/` (submodules
   on their integration branches) and `worktrees/`. It stays open as the home base. The git repo it's
   a checkout of is the **hub repo**.
-- **workspace** = a per-issue worktree *of the hub* — an isolated mini-environment (the hub-repo
-  worktree + nested submodule worktrees + its cmux workspace) for one unit of work.
+- **workspace** = the per-issue, isolated environment for one unit of work — *materialized* as a git
+  *worktree* of the hub (the hub-repo worktree + nested submodule worktrees) plus its cmux workspace.
+  ("worktree" is the git mechanism; "workspace" is the thing you work in.)
 
 Also: **issue** = the work identifier a workspace is keyed on (a tracker issue, a PR/MR, or an
 ad-hoc slug); **PR/MR** = the merge request on whichever forge a submodule lives (GitHub PR, GitLab MR).
@@ -42,7 +43,7 @@ git -C "$(workspace hub)" commit -m "pin <repo> after <description>"
 ```
 
 Submodule commit → hub-repo pin, every time. Stage only the gitlink(s) you changed so the pin commit
-stays focused. **In the worktree-focused workflow, pinning is consolidated into `/update-modules`**
+stays focused. **In the workspace workflow, pinning is consolidated into `/update-modules`**
 (the single pinning path): feature commits land in per-issue *workspaces* and do **not** pin, while
 the hub checkout is fast-forwarded to integration-branch tips and pinned there. The rule above still
 governs any *direct* commit you make in a hub-checkout submodule, but in normal flow feature work
@@ -113,7 +114,7 @@ memory + history). `/workspace` symlinks that project's `memory/` → the canoni
 ## cmux Workflow
 
 cmux is the visual map of in-flight work. Each active issue gets **one cmux workspace** — the
-per-issue worktree — created by `/workspace`. The hub itself stays open as the home base.
+per-issue workspace — created by `/workspace`. The hub itself stays open as the home base.
 
 ### What `/workspace` spawns
 

--- a/claude/commands/teardown.md
+++ b/claude/commands/teardown.md
@@ -28,7 +28,7 @@ The ISSUE-ID argument is **optional**. Resolve the target in this order, then ca
 1. **Explicit arg.** If `$ARGUMENTS` is non-empty, use it as the ISSUE-ID.
 
 2. **Auto-detect the caller workspace.** Identify the cmux workspace this session is running in and
-   read its working directory. If that dir is inside `worktrees/<ISSUE>/`, that's the target (the
+   read its working directory. If that dir is inside `workspaces/<ISSUE>/`, that's the target (the
    common case: "tear down the workspace I'm in"). This call also yields the cmux ref we need to
    close later — run it **regardless** of how ISSUE was resolved:
    ```bash
@@ -39,7 +39,7 @@ The ISSUE-ID argument is **optional**. Resolve the target in this order, then ca
    for w in json.load(sys.stdin)['workspaces']:
        if w['ref'] == caller:
            d = w.get('current_directory') or ''
-           m = re.search(r'/worktrees/([^/]+)', d)
+           m = re.search(r'/workspaces/([^/]+)', d)
            print(f\"{w['ref']}\t{m.group(1) if m else ''}\t{d}\")
    "
    ```
@@ -98,7 +98,7 @@ points at persistent canonical memory).
 ## Step 4 — Commit the manifest (hub repo, via `git -C`)
 No `cd` — operate on the hub the engine reported:
 ```bash
-git -C "$HUB" add worktrees/WORKSPACES.md
+git -C "$HUB" add workspaces/WORKSPACES.md
 git -C "$HUB" commit -m "workspace: close <ISSUE-ID>"
 ```
 Standing housekeeping — no need to ask.

--- a/claude/commands/teardown.md
+++ b/claude/commands/teardown.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Dismantle a per-issue workspace: remove the nested submodule worktrees and the hub-repo worktree,
+  Dismantle a per-issue workspace: remove the nested submodule worktrees and the workspace's top-level worktree,
   prune, and drop the manifest row (committing it). Auto-targets the workspace it's run from. Checks
   for unpushed/uncommitted work (and a running dev stack) and confirms before destroying. Leaves the
   cmux workspace open (closing it is the user's call) and does not delete feature branches.
@@ -91,7 +91,7 @@ Then run the teardown engine (cwd-independent — `workspace` self-anchors):
 ```bash
 workspace teardown --issue <ISSUE-ID>
 ```
-Removes each submodule worktree, then the hub-repo worktree, prunes, and drops the manifest row. It
+Removes each submodule worktree, then the workspace's top-level worktree, prunes, and drops the manifest row. It
 deliberately **leaves** the per-issue memory symlink + history under `~/.claude` untouched (harmless;
 points at persistent canonical memory).
 

--- a/claude/commands/teardown.md
+++ b/claude/commands/teardown.md
@@ -1,0 +1,138 @@
+---
+description: >-
+  Dismantle a per-issue workspace: remove the nested submodule worktrees and the workspace worktree,
+  prune, and drop the manifest row (committing it). Auto-targets the workspace it's run from. Checks
+  for unpushed/uncommitted work (and a running dev stack) and confirms before destroying. Leaves the
+  cmux workspace open (closing it is the user's call) and does not delete feature branches.
+argument-hint: "[ISSUE-ID] (optional — omit to target the current workspace or pick from a list)"
+allowed-tools: Bash Read AskUserQuestion
+disable-model-invocation: true
+---
+Tear down a per-issue workspace (requested target: **$ARGUMENTS**).
+
+This is the `/teardown` command. It removes the worktrees and updates the reconstruction manifest.
+It **leaves the cmux workspace open** — closing it is always the user's decision (offer it, never do
+it automatically). It is intentionally **not** wired to "is the work done?" — you run it when you're
+done with the workspace; the code lives on as commits on the (pushed) feature branches.
+
+> **No `cd`, ever.** The engine (`workspace`, on PATH) self-anchors to the workspace root from
+> anywhere — it climbs out of any submodule before resolving, so the old `.git/modules` trap is
+> gone. Run it directly, and use `git -C "$ROOT"` (with `ROOT="$(workspace root)"` from step 0) for
+> the one workspace-repo commit. Never change directory.
+
+## Step 0 — Resolve the target + workspace root (no `cd`)
+
+The ISSUE-ID argument is **optional**. Resolve the target in this order, then carry the resolved
+**ISSUE-ID**, **cmux workspace ref**, and **`$ROOT`** through the rest of the command:
+
+1. **Explicit arg.** If `$ARGUMENTS` is non-empty, use it as the ISSUE-ID.
+
+2. **Auto-detect the caller workspace.** Identify the cmux workspace this session is running in and
+   read its working directory. If that dir is inside `worktrees/<ISSUE>/`, that's the target (the
+   common case: "tear down the workspace I'm in"). This call also yields the cmux ref we need to
+   close later — run it **regardless** of how ISSUE was resolved:
+   ```bash
+   CALLER=$(cmux identify --json | python3 -c "import sys,json; print(json.load(sys.stdin)['caller']['workspace_ref'])")
+   cmux list-workspaces --json | python3 -c "
+   import sys, json, re
+   caller = '$CALLER'
+   for w in json.load(sys.stdin)['workspaces']:
+       if w['ref'] == caller:
+           d = w.get('current_directory') or ''
+           m = re.search(r'/worktrees/([^/]+)', d)
+           print(f\"{w['ref']}\t{m.group(1) if m else ''}\t{d}\")
+   "
+   ```
+   The three tab-separated fields are: cmux ref to close, ISSUE (empty if at the hub), and the
+   caller's working directory. If ISSUE is empty (you're at the workspace root / hub), fall through
+   to (3) to pick a target.
+
+3. **Pick from a list.** Run `cmux list-workspaces` (plain text shows the
+   `workspace:<N>  <ISSUE-ID> · <title>` names). Filter out non-issue rows (`Root`, etc.) and
+   present the issue workspaces via `AskUserQuestion`. From the chosen row capture both the
+   `workspace:<N>` ref and the ISSUE-ID (token before ` · `).
+
+> **Now resolve the workspace root** for the manifest commit. The engine self-anchors from anywhere,
+> so there's no path to juggle — ask it:
+> ```bash
+> ROOT="$(workspace root)"   # authoritative workspace root, from the hub or any worktree
+> echo "ROOT=$ROOT"
+> ```
+
+## Step 1 — Safety check (engine dry-run) + dev stack
+Ask the engine to report uncommitted/unpushed work — it iterates the submodule worktrees itself, so
+no shell glob and no cwd dependency. If the workflow uses per-issue dev stacks, also detect a
+leftover one:
+```bash
+workspace teardown --issue <ISSUE-ID> --check
+echo "--- dev stack ---"
+docker compose ls --format json 2>/dev/null \
+  | python3 -c "import sys,json; [print(p['Name']) for p in json.load(sys.stdin)]" 2>/dev/null \
+  | grep -i "^$(echo '<ISSUE-ID>' | tr 'A-Z' 'a-z')-" || echo "(no <issue>-* compose project running)"
+```
+The check's final line is `check=clean issue=<ISSUE-ID>` or `check=dirty issue=<ISSUE-ID>`. A running
+`<issue>-*` compose project means the worktree's dev stack is still up and should be brought down in
+step 3.
+
+## Step 2 — Confirm the destructive action (mandatory)
+Teardown is destructive (the engine uses `--force`) and may close the workspace you're sitting in.
+**Always** confirm via `AskUserQuestion` before proceeding — state plainly which ISSUE-ID and which
+cmux workspace will be removed, and surface anything from step 1: uncommitted/unpushed work
+(`check=dirty`) and any running dev stack. If there's unsaved work, recommend running
+`/workspace-sync <ISSUE-ID>` first so it's pushed. Only proceed on explicit confirmation.
+
+## Step 3 — Bring down the dev stack (if any), then run the engine
+If step 1 found a running compose project for this issue, bring it down first (keeps cloned volumes;
+add `--volumes` only if the user wants the data gone):
+```bash
+COMPOSE_PROJECT_NAME=<issue>-<svc> docker compose -f <issue-worktree>/modules/<repo>/docker-compose.yml down
+```
+Then run the teardown engine (cwd-independent — `workspace` self-anchors):
+```bash
+workspace teardown --issue <ISSUE-ID>
+```
+Removes each submodule worktree, then the workspace worktree, prunes, and drops the manifest row. It
+deliberately **leaves** the per-issue memory symlink + history under `~/.claude` untouched (harmless;
+points at persistent canonical memory).
+
+## Step 4 — Commit the manifest (workspace repo, via `git -C`)
+No `cd` — operate on the workspace root the engine reported:
+```bash
+git -C "$ROOT" add worktrees/WORKSPACES.md
+git -C "$ROOT" commit -m "workspace: close <ISSUE-ID>"
+```
+Standing housekeeping — no need to ask.
+
+## Step 5 — Report, then *offer* to close the cmux workspace (never auto-close)
+Report the outcome as text. The worktrees are gone and the manifest is committed; the cmux workspace
+itself stays open. **Closing it is the user's decision — never close it automatically.**
+
+Offer it explicitly, surfacing the resolved `workspace:<N>` ref from step 0 (e.g. "The worktrees are
+torn down. Want me to close the cmux workspace `workspace:<N>`?"). Only if the user confirms, run the
+close as a **synchronous** call (do **not** background it; the Bash tool reaps lingering children, so
+a backgrounded close is killed before its RPC fires). Use the **literal** ref — shell variables don't
+persist across Bash calls:
+
+```bash
+cmux close-workspace --workspace workspace:<N>
+```
+
+Note that closing the **caller** workspace (the one you're sitting in) ends this Claude session; the
+synchronous call delivers the RPC before the CLI returns and your report text already rendered, so
+don't expect to print anything after it. Closing a **non-caller** (picked from the hub) leaves the
+session alive — verify with `cmux list-workspaces` if you like.
+
+Also note that the **feature branch(es) are intentionally kept** (the work may be unmerged) — offer
+to delete local branches only if the user confirms they're merged.
+
+## Guardrails
+- **No `cd` — call `workspace` (on PATH) directly and use `git -C "$ROOT"`** — see step 0. The engine
+  self-anchors to the workspace root from anywhere (climbing out of any submodule), so the old
+  `.git/modules` anchoring trap is gone.
+- **Never destroy unsaved work silently** — the step-2 confirmation is mandatory, every time.
+- **Don't delete feature branches** unless the user confirms they're merged.
+- **Never auto-close the cmux workspace** — see step 5. Teardown removes the *worktrees* and leaves
+  the workspace open; offer to close it and only do so on explicit confirmation. When the user does
+  confirm, close **synchronously, never backgrounded**. All durable state (worktree removal, manifest
+  commit) already landed in steps 3–4, so an unclosed workspace is harmless — recover/close it from
+  any session with `cmux close-workspace --workspace workspace:<N>`.

--- a/claude/commands/teardown.md
+++ b/claude/commands/teardown.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Dismantle a per-issue workspace: remove the nested submodule worktrees and the workspace worktree,
+  Dismantle a per-issue workspace: remove the nested submodule worktrees and the hub-repo worktree,
   prune, and drop the manifest row (committing it). Auto-targets the workspace it's run from. Checks
   for unpushed/uncommitted work (and a running dev stack) and confirms before destroying. Leaves the
   cmux workspace open (closing it is the user's call) and does not delete feature branches.
@@ -91,7 +91,7 @@ Then run the teardown engine (cwd-independent — `workspace` self-anchors):
 ```bash
 workspace teardown --issue <ISSUE-ID>
 ```
-Removes each submodule worktree, then the workspace worktree, prunes, and drops the manifest row. It
+Removes each submodule worktree, then the hub-repo worktree, prunes, and drops the manifest row. It
 deliberately **leaves** the per-issue memory symlink + history under `~/.claude` untouched (harmless;
 points at persistent canonical memory).
 

--- a/claude/commands/teardown.md
+++ b/claude/commands/teardown.md
@@ -43,8 +43,8 @@ The ISSUE-ID argument is **optional**. Resolve the target in this order, then ca
            print(f\"{w['ref']}\t{m.group(1) if m else ''}\t{d}\")
    "
    ```
-   The three tab-separated fields are: cmux ref to close, ISSUE (empty if at the hub), and the
-   caller's working directory. If ISSUE is empty (you're at the hub), fall through to (3) to pick a
+   The three tab-separated fields are: cmux ref to close, ISSUE (empty if at the hub root), and the
+   caller's working directory. If ISSUE is empty (you're at the hub root), fall through to (3) to pick a
    target.
 
 3. **Pick from a list.** Run `cmux list-workspaces` (plain text shows the

--- a/claude/commands/teardown.md
+++ b/claude/commands/teardown.md
@@ -15,15 +15,15 @@ It **leaves the cmux workspace open** — closing it is always the user's decisi
 it automatically). It is intentionally **not** wired to "is the work done?" — you run it when you're
 done with the workspace; the code lives on as commits on the (pushed) feature branches.
 
-> **No `cd`, ever.** The engine (`workspace`, on PATH) self-anchors to the workspace root from
-> anywhere — it climbs out of any submodule before resolving, so the old `.git/modules` trap is
-> gone. Run it directly, and use `git -C "$ROOT"` (with `ROOT="$(workspace root)"` from step 0) for
-> the one workspace-repo commit. Never change directory.
+> **No `cd`, ever.** The engine (`workspace`, on PATH) self-anchors to the hub from anywhere — it
+> climbs out of any submodule before resolving, so the old `.git/modules` trap is gone. Run it
+> directly, and use `git -C "$HUB"` (with `HUB="$(workspace hub)"` from step 0) for the one hub-repo
+> commit. Never change directory.
 
-## Step 0 — Resolve the target + workspace root (no `cd`)
+## Step 0 — Resolve the target + hub (no `cd`)
 
 The ISSUE-ID argument is **optional**. Resolve the target in this order, then carry the resolved
-**ISSUE-ID**, **cmux workspace ref**, and **`$ROOT`** through the rest of the command:
+**ISSUE-ID**, **cmux workspace ref**, and **`$HUB`** through the rest of the command:
 
 1. **Explicit arg.** If `$ARGUMENTS` is non-empty, use it as the ISSUE-ID.
 
@@ -44,19 +44,19 @@ The ISSUE-ID argument is **optional**. Resolve the target in this order, then ca
    "
    ```
    The three tab-separated fields are: cmux ref to close, ISSUE (empty if at the hub), and the
-   caller's working directory. If ISSUE is empty (you're at the workspace root / hub), fall through
-   to (3) to pick a target.
+   caller's working directory. If ISSUE is empty (you're at the hub), fall through to (3) to pick a
+   target.
 
 3. **Pick from a list.** Run `cmux list-workspaces` (plain text shows the
    `workspace:<N>  <ISSUE-ID> · <title>` names). Filter out non-issue rows (`Root`, etc.) and
    present the issue workspaces via `AskUserQuestion`. From the chosen row capture both the
    `workspace:<N>` ref and the ISSUE-ID (token before ` · `).
 
-> **Now resolve the workspace root** for the manifest commit. The engine self-anchors from anywhere,
-> so there's no path to juggle — ask it:
+> **Now resolve the hub** for the manifest commit. The engine self-anchors from anywhere, so
+> there's no path to juggle — ask it:
 > ```bash
-> ROOT="$(workspace root)"   # authoritative workspace root, from the hub or any worktree
-> echo "ROOT=$ROOT"
+> HUB="$(workspace hub)"   # authoritative hub path, from the hub or any workspace
+> echo "HUB=$HUB"
 > ```
 
 ## Step 1 — Safety check (engine dry-run) + dev stack
@@ -95,11 +95,11 @@ Removes each submodule worktree, then the workspace worktree, prunes, and drops 
 deliberately **leaves** the per-issue memory symlink + history under `~/.claude` untouched (harmless;
 points at persistent canonical memory).
 
-## Step 4 — Commit the manifest (workspace repo, via `git -C`)
-No `cd` — operate on the workspace root the engine reported:
+## Step 4 — Commit the manifest (hub repo, via `git -C`)
+No `cd` — operate on the hub the engine reported:
 ```bash
-git -C "$ROOT" add worktrees/WORKSPACES.md
-git -C "$ROOT" commit -m "workspace: close <ISSUE-ID>"
+git -C "$HUB" add worktrees/WORKSPACES.md
+git -C "$HUB" commit -m "workspace: close <ISSUE-ID>"
 ```
 Standing housekeeping — no need to ask.
 
@@ -126,9 +126,9 @@ Also note that the **feature branch(es) are intentionally kept** (the work may b
 to delete local branches only if the user confirms they're merged.
 
 ## Guardrails
-- **No `cd` — call `workspace` (on PATH) directly and use `git -C "$ROOT"`** — see step 0. The engine
-  self-anchors to the workspace root from anywhere (climbing out of any submodule), so the old
-  `.git/modules` anchoring trap is gone.
+- **No `cd` — call `workspace` (on PATH) directly and use `git -C "$HUB"`** — see step 0. The engine
+  self-anchors to the hub from anywhere (climbing out of any submodule), so the old `.git/modules`
+  anchoring trap is gone.
 - **Never destroy unsaved work silently** — the step-2 confirmation is mandatory, every time.
 - **Don't delete feature branches** unless the user confirms they're merged.
 - **Never auto-close the cmux workspace** — see step 5. Teardown removes the *worktrees* and leaves

--- a/claude/commands/update-modules.md
+++ b/claude/commands/update-modules.md
@@ -1,0 +1,58 @@
+---
+description: >-
+  Fast-forward the top-level workspace checkout's submodule pointers to their integration branch
+  tips, then pin the moved submodules in the workspace repo. The single, deliberate pinning path.
+  Run after upstream PRs/MRs merge.
+argument-hint: "[--repos repo-a,repo-b] (optional; defaults to all)"
+allowed-tools: Bash Read
+disable-model-invocation: true
+---
+Refresh the workspace's stable integration view: **$ARGUMENTS**
+
+This is the `/update-modules` command. In the worktree-focused workflow, the top-level submodule
+checkouts always sit on their integration branches and act as a clean, stable vantage point. This
+command catches them up to upstream and pins them. It is the **only** place pinning happens —
+per-issue worktrees never pin.
+
+> **No `cd`, ever.** The engine (`workspace`, on PATH) self-anchors to the workspace root from
+> anywhere — it climbs out of any submodule before resolving — so the fast-forward and pin always
+> act on the top-level checkout, not a worktree. Resolve the root once for the pin commit:
+> ```bash
+> ROOT="$(workspace root)"; echo "ROOT=$ROOT"
+> ```
+
+## Steps
+
+### 1. Run the engine
+```bash
+workspace update-modules $ARGUMENTS
+```
+For each submodule, the engine resolves its integration branch from the **current checkout**,
+fetches, and `git merge --ff-only`. Output lines:
+- `MOVED <repo>: <old> → <new> (<branch>)` — fast-forwarded.
+- `OK <repo>: already current …` — nothing to do.
+- `SKIP <repo>: … not a fast-forward …` — diverged or has local commits; relay and leave it.
+- A trailing `PIN:<repo> <repo>…` line lists the submodules that moved.
+
+### 2. Surface divergence warnings
+The engine warns (stderr) when a submodule is on a branch other than its `origin/HEAD` default (e.g.
+still on a feature branch in the main checkout). Relay these — they usually mean the **one-time
+migration** hasn't run, or feature work leaked into the main checkout. Suggest the migration if so.
+
+### 3. Pin the moved submodules (workspace repo)
+For exactly the repos in the `PIN:` line, stage those gitlinks and commit — standing housekeeping,
+no need to ask:
+```bash
+git -C "$ROOT" add modules/<moved-repo> [modules/<moved-repo> …]
+git -C "$ROOT" commit -m "pin <repos> after fast-forward to <branch> tip(s)"
+```
+If nothing moved (`PIN:` absent), there's nothing to pin — say so.
+
+### 4. Report
+List what moved, what was already current, and anything skipped.
+
+## Guardrails
+- **Fast-forward only** — never merge-commit or reset the main checkout here. A `SKIP` means the
+  user must reconcile manually (the main checkout shouldn't have local commits).
+- **Pin only what moved** — keep the pin commit focused (per the auto-pin convention).
+- **This is the only pinning path** — don't pin from inside per-issue worktrees.

--- a/claude/commands/update-modules.md
+++ b/claude/commands/update-modules.md
@@ -1,24 +1,24 @@
 ---
 description: >-
-  Fast-forward the top-level workspace checkout's submodule pointers to their integration branch
-  tips, then pin the moved submodules in the workspace repo. The single, deliberate pinning path.
-  Run after upstream PRs/MRs merge.
+  Fast-forward the hub checkout's submodule pointers to their integration branch tips, then pin the
+  moved submodules in the hub repo. The single, deliberate pinning path. Run after upstream PRs/MRs
+  merge.
 argument-hint: "[--repos repo-a,repo-b] (optional; defaults to all)"
 allowed-tools: Bash Read
 disable-model-invocation: true
 ---
-Refresh the workspace's stable integration view: **$ARGUMENTS**
+Refresh the hub's stable integration view: **$ARGUMENTS**
 
-This is the `/update-modules` command. In the worktree-focused workflow, the top-level submodule
+This is the `/update-modules` command. In the worktree-focused workflow, the hub's submodule
 checkouts always sit on their integration branches and act as a clean, stable vantage point. This
 command catches them up to upstream and pins them. It is the **only** place pinning happens —
-per-issue worktrees never pin.
+per-issue workspaces never pin.
 
-> **No `cd`, ever.** The engine (`workspace`, on PATH) self-anchors to the workspace root from
-> anywhere — it climbs out of any submodule before resolving — so the fast-forward and pin always
-> act on the top-level checkout, not a worktree. Resolve the root once for the pin commit:
+> **No `cd`, ever.** The engine (`workspace`, on PATH) self-anchors to the hub from anywhere — it
+> climbs out of any submodule before resolving — so the fast-forward and pin always act on the hub
+> checkout, not a workspace. Resolve the hub once for the pin commit:
 > ```bash
-> ROOT="$(workspace root)"; echo "ROOT=$ROOT"
+> HUB="$(workspace hub)"; echo "HUB=$HUB"
 > ```
 
 ## Steps
@@ -36,15 +36,15 @@ fetches, and `git merge --ff-only`. Output lines:
 
 ### 2. Surface divergence warnings
 The engine warns (stderr) when a submodule is on a branch other than its `origin/HEAD` default (e.g.
-still on a feature branch in the main checkout). Relay these — they usually mean the **one-time
-migration** hasn't run, or feature work leaked into the main checkout. Suggest the migration if so.
+still on a feature branch in the hub checkout). Relay these — they usually mean the **one-time
+migration** hasn't run, or feature work leaked into the hub checkout. Suggest the migration if so.
 
-### 3. Pin the moved submodules (workspace repo)
+### 3. Pin the moved submodules (hub repo)
 For exactly the repos in the `PIN:` line, stage those gitlinks and commit — standing housekeeping,
 no need to ask:
 ```bash
-git -C "$ROOT" add modules/<moved-repo> [modules/<moved-repo> …]
-git -C "$ROOT" commit -m "pin <repos> after fast-forward to <branch> tip(s)"
+git -C "$HUB" add modules/<moved-repo> [modules/<moved-repo> …]
+git -C "$HUB" commit -m "pin <repos> after fast-forward to <branch> tip(s)"
 ```
 If nothing moved (`PIN:` absent), there's nothing to pin — say so.
 
@@ -52,7 +52,7 @@ If nothing moved (`PIN:` absent), there's nothing to pin — say so.
 List what moved, what was already current, and anything skipped.
 
 ## Guardrails
-- **Fast-forward only** — never merge-commit or reset the main checkout here. A `SKIP` means the
-  user must reconcile manually (the main checkout shouldn't have local commits).
+- **Fast-forward only** — never merge-commit or reset the hub checkout here. A `SKIP` means the
+  user must reconcile manually (the hub checkout shouldn't have local commits).
 - **Pin only what moved** — keep the pin commit focused (per the auto-pin convention).
-- **This is the only pinning path** — don't pin from inside per-issue worktrees.
+- **This is the only pinning path** — don't pin from inside per-issue workspaces.

--- a/claude/commands/update-modules.md
+++ b/claude/commands/update-modules.md
@@ -9,7 +9,7 @@ disable-model-invocation: true
 ---
 Refresh the hub's stable integration view: **$ARGUMENTS**
 
-This is the `/update-modules` command. In the worktree-focused workflow, the hub's submodule
+This is the `/update-modules` command. In the workspace workflow, the hub's submodule
 checkouts always sit on their integration branches and act as a clean, stable vantage point. This
 command catches them up to upstream and pins them. It is the **only** place pinning happens —
 per-issue workspaces never pin.

--- a/claude/commands/workspace-sync.md
+++ b/claude/commands/workspace-sync.md
@@ -1,0 +1,143 @@
+---
+description: >-
+  Bring a per-issue workspace's feature branches up to date by MERGING each submodule's integration
+  branch in (never rebase), then pushing. Auto-resolves mechanical merge conflicts (e.g. append-only
+  migration lists); asks you when a resolution is ambiguous. Auto-targets the cmux workspace it's run
+  from. Does not touch the tracker or the workspace repo.
+argument-hint: "[ISSUE-ID] (optional — omit to target the current workspace or pick from a list)"
+allowed-tools: Bash Read Edit AskUserQuestion
+disable-model-invocation: true
+---
+Sync a per-issue workspace (requested target: **$ARGUMENTS**).
+
+This is the `/workspace-sync` command. It keeps the issue's feature branch(es) current with their
+integration branches and pushes — so the work is durable and the manifest stays a valid
+reconstruction recipe. **Merge strategy (not rebase)**: no history rewriting, no force-push,
+PR/MR-review-friendly. When a merge conflicts, this command **resolves it** (automatically for
+mechanical collisions, with your input when the right answer is unclear) rather than stopping.
+
+## Step 0 — Resolve the target workspace
+
+The ISSUE-ID argument is **optional**. Resolve the target in this order, then carry the resolved
+**ISSUE-ID** through the rest of the command (no `cd` — the engine self-anchors; resolve
+`ROOT="$(workspace root)"` once for the manifest-fallback read and absolute worktree paths):
+
+1. **Explicit arg.** If `$ARGUMENTS` is non-empty, use it as the ISSUE-ID.
+
+2. **Auto-detect the caller workspace.** Otherwise, identify the cmux workspace this session is
+   running in and read its working directory — if that dir is inside `worktrees/<ISSUE>/`, that's
+   the target (the common case: "sync the workspace I'm in"):
+   ```bash
+   CALLER=$(cmux identify --json | python3 -c "import sys,json; print(json.load(sys.stdin)['caller']['workspace_ref'])")
+   cmux list-workspaces --json | python3 -c "
+   import sys, json, re
+   caller = '$CALLER'
+   for w in json.load(sys.stdin)['workspaces']:
+       if w['ref'] == caller:
+           m = re.search(r'/worktrees/([^/]+)', w.get('current_directory') or '')
+           print(m.group(1) if m else '')
+   "
+   ```
+   If a non-empty ISSUE is printed, that's the target. If empty (e.g. you're at the workspace root /
+   hub), fall through to (3).
+
+3. **Pick from a list.** Run `cmux list-workspaces` (plain text shows the
+   `workspace:<N>  <ISSUE-ID> · <title>` names). Filter out non-issue rows (`Root`, etc.) and
+   present the issue workspaces via `AskUserQuestion`. Capture the ISSUE-ID (token before ` · `). As
+   a fallback, the manifest also lists active workspaces:
+   `git -C "$ROOT" show HEAD:worktrees/WORKSPACES.md`.
+
+## Step 1 — Run the engine
+```bash
+workspace sync --issue <ISSUE-ID>
+```
+For each in-scope submodule worktree under `worktrees/<ISSUE-ID>/modules/<repo>`, the engine:
+`fetch origin/<integration-branch>` → `git merge --no-edit origin/<integration-branch>` →
+`git push` (plain; sets upstream on first push). The integration branch is resolved from the
+**top-level** checkout.
+
+The engine prints one line per submodule:
+- `OK <repo>: …` — merged + pushed. Nothing more to do.
+- `CONFLICT <repo>: …` — the merge is **left in progress** in `worktrees/<ISSUE-ID>/modules/<repo>`.
+  Go to step 2. (The engine stops at the first conflict and exits non-zero; that's expected — this
+  command drives the resolution and re-runs.)
+- `ERROR <repo>: …` — fetch/push failed (offline, network, or remote moved). Relay it; not a conflict.
+
+## Step 2 — Resolve conflicts (auto where mechanical, ask where ambiguous)
+
+For each repo the engine reported `CONFLICT`, work inside its worktree
+(`$ROOT/worktrees/<ISSUE-ID>/modules/<repo>`). List the unmerged files:
+```bash
+git -C "$ROOT/worktrees/<ISSUE-ID>/modules/<repo>" diff --name-only --diff-filter=U
+```
+Resolve **every** conflicted file with the right tier below, then complete the merge.
+
+### Tier A — Auto-resolve mechanical collisions (no need to ask)
+
+These have one objectively-correct resolution. Resolve them directly (Edit), then continue.
+
+- **Pure-append registries** — both sides append distinct lines to an ordered/append-only list and
+  nothing else conflicts. **Resolution: union both sides**, deduped, preserving the file's existing
+  order. The overwhelmingly common case is a **migration version list** (e.g. each branch appended
+  its migration's `('<version>'),` line to a `schema_migrations` VALUES list): union all version
+  lines from both `HEAD` and the incoming side, deduped, sorted to match the file's existing order,
+  replacing the whole `<<<<<<< … >>>>>>>` block (including any `|||||||` diff3 base section).
+  **Guard:** this is Tier A only when the conflict is confined to the append-only list and every
+  conflicting line is a bare list entry. If the file has conflict hunks *elsewhere* (real divergence
+  — a column/index/table or other logic defined differently on each side), those hunks are **Tier B**.
+  Only union when you can see neither side *edited* the other's lines; when unsure, drop to Tier B.
+
+### Tier B — Ask the user (ambiguous / semantic conflicts)
+
+For any conflict where the correct merge isn't a mechanical union — overlapping edits to the same
+code, schema/DDL divergence, logic both sides changed — **do not guess**. Read the conflict hunks so
+you can describe them concretely:
+```bash
+git -C "$ROOT/worktrees/<ISSUE-ID>/modules/<repo>" diff --diff-filter=U -- <file>
+```
+Then present the decision via `AskUserQuestion`, one question per conflicted file (or per hunk if a
+file has several distinct ones). State the file/path and summarize what each side did. Offer:
+- **A specific merged resolution you recommend** (first option) — describe exactly what it keeps from each side.
+- **Take the integration branch's version** (theirs — the incoming side).
+- **Keep the feature branch's version** (ours — the work in this worktree).
+- (The user can always pick "Other" to describe a custom resolution.)
+
+Apply the chosen resolution with Edit (for a hand-merged result) or, for a clean whole-file pick,
+`git -C <worktree> checkout --ours <file>` / `--theirs <file>`. **Never silently discard either
+side's changes** — that's exactly what Tier B exists to prevent.
+
+### Complete the merge
+
+Once a repo's files are all resolved (no markers remain — verify with
+`grep -rn '^<<<<<<<\|^|||||||\|^=======\|^>>>>>>>' <files>`), stage and commit the merge:
+```bash
+git -C "$ROOT/worktrees/<ISSUE-ID>/modules/<repo>" add <resolved files>
+git -C "$ROOT/worktrees/<ISSUE-ID>/modules/<repo>" commit --no-edit
+```
+
+## Step 3 — Re-run the engine to push (and catch any later repos)
+```bash
+workspace sync --issue <ISSUE-ID>
+```
+Re-running is idempotent: already-merged repos do an "already up to date" merge and push; any repo
+the engine hadn't reached yet (it stops at the first conflict) now gets its turn. Repeat steps 2–3
+until every repo reports `OK`.
+
+**Pre-push hook note:** if a repo's pre-push hooks (linters, type-checks) require running dev
+services and the push fails *only* because those services aren't up — and the failures are in files
+pulled in by the merge, not this branch's own changes — say so and offer either to bring up the
+worktree's dev stack and re-push, or to push with `--no-verify`. Don't bypass hooks when the
+failures implicate this branch's actual changes.
+
+## Step 4 — Summarize
+Report which repos synced cleanly, which conflicts were auto-resolved (and how), which you asked
+about (and the chosen resolution), and anything still needing attention.
+
+## Guardrails
+- **Merge, never rebase** — the engine enforces this; don't manually rebase feature branches here.
+- **Never force-push.**
+- **Auto-resolve only mechanical collisions** (Tier A) — union-style appends where neither side
+  edited the other's lines. Everything semantic is **Tier B → ask**; never guess a code merge.
+- **Never silently drop a side's changes** — a Tier-B resolution always reflects an explicit choice.
+- **No tracker, no workspace-repo commit** — posting a changeset summary to the issue is done by
+  hand (out of scope for this command).

--- a/claude/commands/workspace-sync.md
+++ b/claude/commands/workspace-sync.md
@@ -38,7 +38,7 @@ The ISSUE-ID argument is **optional**. Resolve the target in this order, then ca
            print(m.group(1) if m else '')
    "
    ```
-   If a non-empty ISSUE is printed, that's the target. If empty (e.g. you're at the hub), fall
+   If a non-empty ISSUE is printed, that's the target. If empty (e.g. you're at the hub root), fall
    through to (3).
 
 3. **Pick from a list.** Run `cmux list-workspaces` (plain text shows the

--- a/claude/commands/workspace-sync.md
+++ b/claude/commands/workspace-sync.md
@@ -3,7 +3,7 @@ description: >-
   Bring a per-issue workspace's feature branches up to date by MERGING each submodule's integration
   branch in (never rebase), then pushing. Auto-resolves mechanical merge conflicts (e.g. append-only
   migration lists); asks you when a resolution is ambiguous. Auto-targets the cmux workspace it's run
-  from. Does not touch the tracker or the workspace repo.
+  from. Does not touch the tracker or the hub repo.
 argument-hint: "[ISSUE-ID] (optional — omit to target the current workspace or pick from a list)"
 allowed-tools: Bash Read Edit AskUserQuestion
 disable-model-invocation: true
@@ -20,7 +20,7 @@ mechanical collisions, with your input when the right answer is unclear) rather 
 
 The ISSUE-ID argument is **optional**. Resolve the target in this order, then carry the resolved
 **ISSUE-ID** through the rest of the command (no `cd` — the engine self-anchors; resolve
-`ROOT="$(workspace root)"` once for the manifest-fallback read and absolute worktree paths):
+`HUB="$(workspace hub)"` once for the manifest-fallback read and absolute worktree paths):
 
 1. **Explicit arg.** If `$ARGUMENTS` is non-empty, use it as the ISSUE-ID.
 
@@ -38,14 +38,14 @@ The ISSUE-ID argument is **optional**. Resolve the target in this order, then ca
            print(m.group(1) if m else '')
    "
    ```
-   If a non-empty ISSUE is printed, that's the target. If empty (e.g. you're at the workspace root /
-   hub), fall through to (3).
+   If a non-empty ISSUE is printed, that's the target. If empty (e.g. you're at the hub), fall
+   through to (3).
 
 3. **Pick from a list.** Run `cmux list-workspaces` (plain text shows the
    `workspace:<N>  <ISSUE-ID> · <title>` names). Filter out non-issue rows (`Root`, etc.) and
    present the issue workspaces via `AskUserQuestion`. Capture the ISSUE-ID (token before ` · `). As
    a fallback, the manifest also lists active workspaces:
-   `git -C "$ROOT" show HEAD:worktrees/WORKSPACES.md`.
+   `git -C "$HUB" show HEAD:worktrees/WORKSPACES.md`.
 
 ## Step 1 — Run the engine
 ```bash
@@ -66,9 +66,9 @@ The engine prints one line per submodule:
 ## Step 2 — Resolve conflicts (auto where mechanical, ask where ambiguous)
 
 For each repo the engine reported `CONFLICT`, work inside its worktree
-(`$ROOT/worktrees/<ISSUE-ID>/modules/<repo>`). List the unmerged files:
+(`$HUB/worktrees/<ISSUE-ID>/modules/<repo>`). List the unmerged files:
 ```bash
-git -C "$ROOT/worktrees/<ISSUE-ID>/modules/<repo>" diff --name-only --diff-filter=U
+git -C "$HUB/worktrees/<ISSUE-ID>/modules/<repo>" diff --name-only --diff-filter=U
 ```
 Resolve **every** conflicted file with the right tier below, then complete the merge.
 
@@ -93,7 +93,7 @@ For any conflict where the correct merge isn't a mechanical union — overlappin
 code, schema/DDL divergence, logic both sides changed — **do not guess**. Read the conflict hunks so
 you can describe them concretely:
 ```bash
-git -C "$ROOT/worktrees/<ISSUE-ID>/modules/<repo>" diff --diff-filter=U -- <file>
+git -C "$HUB/worktrees/<ISSUE-ID>/modules/<repo>" diff --diff-filter=U -- <file>
 ```
 Then present the decision via `AskUserQuestion`, one question per conflicted file (or per hunk if a
 file has several distinct ones). State the file/path and summarize what each side did. Offer:
@@ -111,8 +111,8 @@ side's changes** — that's exactly what Tier B exists to prevent.
 Once a repo's files are all resolved (no markers remain — verify with
 `grep -rn '^<<<<<<<\|^|||||||\|^=======\|^>>>>>>>' <files>`), stage and commit the merge:
 ```bash
-git -C "$ROOT/worktrees/<ISSUE-ID>/modules/<repo>" add <resolved files>
-git -C "$ROOT/worktrees/<ISSUE-ID>/modules/<repo>" commit --no-edit
+git -C "$HUB/worktrees/<ISSUE-ID>/modules/<repo>" add <resolved files>
+git -C "$HUB/worktrees/<ISSUE-ID>/modules/<repo>" commit --no-edit
 ```
 
 ## Step 3 — Re-run the engine to push (and catch any later repos)
@@ -139,5 +139,5 @@ about (and the chosen resolution), and anything still needing attention.
 - **Auto-resolve only mechanical collisions** (Tier A) — union-style appends where neither side
   edited the other's lines. Everything semantic is **Tier B → ask**; never guess a code merge.
 - **Never silently drop a side's changes** — a Tier-B resolution always reflects an explicit choice.
-- **No tracker, no workspace-repo commit** — posting a changeset summary to the issue is done by
+- **No tracker, no hub-repo commit** — posting a changeset summary to the issue is done by
   hand (out of scope for this command).

--- a/claude/commands/workspace-sync.md
+++ b/claude/commands/workspace-sync.md
@@ -25,7 +25,7 @@ The ISSUE-ID argument is **optional**. Resolve the target in this order, then ca
 1. **Explicit arg.** If `$ARGUMENTS` is non-empty, use it as the ISSUE-ID.
 
 2. **Auto-detect the caller workspace.** Otherwise, identify the cmux workspace this session is
-   running in and read its working directory — if that dir is inside `worktrees/<ISSUE>/`, that's
+   running in and read its working directory — if that dir is inside `workspaces/<ISSUE>/`, that's
    the target (the common case: "sync the workspace I'm in"):
    ```bash
    CALLER=$(cmux identify --json | python3 -c "import sys,json; print(json.load(sys.stdin)['caller']['workspace_ref'])")
@@ -34,7 +34,7 @@ The ISSUE-ID argument is **optional**. Resolve the target in this order, then ca
    caller = '$CALLER'
    for w in json.load(sys.stdin)['workspaces']:
        if w['ref'] == caller:
-           m = re.search(r'/worktrees/([^/]+)', w.get('current_directory') or '')
+           m = re.search(r'/workspaces/([^/]+)', w.get('current_directory') or '')
            print(m.group(1) if m else '')
    "
    ```
@@ -45,20 +45,20 @@ The ISSUE-ID argument is **optional**. Resolve the target in this order, then ca
    `workspace:<N>  <ISSUE-ID> · <title>` names). Filter out non-issue rows (`Root`, etc.) and
    present the issue workspaces via `AskUserQuestion`. Capture the ISSUE-ID (token before ` · `). As
    a fallback, the manifest also lists active workspaces:
-   `git -C "$HUB" show HEAD:worktrees/WORKSPACES.md`.
+   `git -C "$HUB" show HEAD:workspaces/WORKSPACES.md`.
 
 ## Step 1 — Run the engine
 ```bash
 workspace sync --issue <ISSUE-ID>
 ```
-For each in-scope submodule worktree under `worktrees/<ISSUE-ID>/modules/<repo>`, the engine:
+For each in-scope submodule worktree under `workspaces/<ISSUE-ID>/modules/<repo>`, the engine:
 `fetch origin/<integration-branch>` → `git merge --no-edit origin/<integration-branch>` →
 `git push` (plain; sets upstream on first push). The integration branch is resolved from the
 **top-level** checkout.
 
 The engine prints one line per submodule:
 - `OK <repo>: …` — merged + pushed. Nothing more to do.
-- `CONFLICT <repo>: …` — the merge is **left in progress** in `worktrees/<ISSUE-ID>/modules/<repo>`.
+- `CONFLICT <repo>: …` — the merge is **left in progress** in `workspaces/<ISSUE-ID>/modules/<repo>`.
   Go to step 2. (The engine stops at the first conflict and exits non-zero; that's expected — this
   command drives the resolution and re-runs.)
 - `ERROR <repo>: …` — fetch/push failed (offline, network, or remote moved). Relay it; not a conflict.
@@ -66,9 +66,9 @@ The engine prints one line per submodule:
 ## Step 2 — Resolve conflicts (auto where mechanical, ask where ambiguous)
 
 For each repo the engine reported `CONFLICT`, work inside its worktree
-(`$HUB/worktrees/<ISSUE-ID>/modules/<repo>`). List the unmerged files:
+(`$HUB/workspaces/<ISSUE-ID>/modules/<repo>`). List the unmerged files:
 ```bash
-git -C "$HUB/worktrees/<ISSUE-ID>/modules/<repo>" diff --name-only --diff-filter=U
+git -C "$HUB/workspaces/<ISSUE-ID>/modules/<repo>" diff --name-only --diff-filter=U
 ```
 Resolve **every** conflicted file with the right tier below, then complete the merge.
 
@@ -93,7 +93,7 @@ For any conflict where the correct merge isn't a mechanical union — overlappin
 code, schema/DDL divergence, logic both sides changed — **do not guess**. Read the conflict hunks so
 you can describe them concretely:
 ```bash
-git -C "$HUB/worktrees/<ISSUE-ID>/modules/<repo>" diff --diff-filter=U -- <file>
+git -C "$HUB/workspaces/<ISSUE-ID>/modules/<repo>" diff --diff-filter=U -- <file>
 ```
 Then present the decision via `AskUserQuestion`, one question per conflicted file (or per hunk if a
 file has several distinct ones). State the file/path and summarize what each side did. Offer:
@@ -111,8 +111,8 @@ side's changes** — that's exactly what Tier B exists to prevent.
 Once a repo's files are all resolved (no markers remain — verify with
 `grep -rn '^<<<<<<<\|^|||||||\|^=======\|^>>>>>>>' <files>`), stage and commit the merge:
 ```bash
-git -C "$HUB/worktrees/<ISSUE-ID>/modules/<repo>" add <resolved files>
-git -C "$HUB/worktrees/<ISSUE-ID>/modules/<repo>" commit --no-edit
+git -C "$HUB/workspaces/<ISSUE-ID>/modules/<repo>" add <resolved files>
+git -C "$HUB/workspaces/<ISSUE-ID>/modules/<repo>" commit --no-edit
 ```
 
 ## Step 3 — Re-run the engine to push (and catch any later repos)

--- a/claude/commands/workspace.md
+++ b/claude/commands/workspace.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Instantiate a fully-isolated, per-issue mini-workspace: a worktree of the workspace repo with
+  Instantiate a fully-isolated, per-issue workspace: a worktree of the hub repo with
   nested worktrees of the in-scope submodules on the issue's feature branch, shared memory, a
   tracked manifest row, and a cmux workspace cwd'd into it. Claude suggests the repo scope; you
   confirm. Targets a tracker issue or a PR/MR.
@@ -12,13 +12,13 @@ Create an isolated per-issue workspace for: **$ARGUMENTS**
 
 This is the `/workspace` command of the worktree-focused workflow (see the workspace guide →
 "Per-issue worktree workspaces"). The engine is `workspace`; this command orchestrates the
-tracker, scope confirmation, the workspace-repo commit, and the cmux spawn.
+tracker, scope confirmation, the hub-repo commit, and the cmux spawn.
 
-> **No `cd`, ever.** The engine (`workspace`, on PATH) self-anchors to the workspace root from
-> anywhere — it climbs out of any submodule before resolving. Resolve the root once for the
-> manifest commit and the spawn cwd, and use `git -C "$ROOT"`:
+> **No `cd`, ever.** The engine (`workspace`, on PATH) self-anchors to the hub from anywhere — it
+> climbs out of any submodule before resolving. Resolve the hub once for the manifest commit and the
+> spawn cwd, and use `git -C "$HUB"`:
 > ```bash
-> ROOT="$(workspace root)"; echo "ROOT=$ROOT"
+> HUB="$(workspace hub)"; echo "HUB=$HUB"
 > ```
 
 ## Steps
@@ -82,11 +82,11 @@ workspace create \
 Capture `workspace_dir=` from the final stdout line. Idempotent — safe to re-run; it also
 **restores** branches that already exist on the remote (the rebuild path).
 
-### 5. Commit the manifest (workspace repo)
+### 5. Commit the manifest (hub repo)
 The engine wrote `worktrees/WORKSPACES.md` but did not commit:
 ```bash
-git -C "$ROOT" add worktrees/WORKSPACES.md
-git -C "$ROOT" commit -m "workspace: open <ID> (<repos>)"
+git -C "$HUB" add worktrees/WORKSPACES.md
+git -C "$HUB" commit -m "workspace: open <ID> (<repos>)"
 ```
 This is standing housekeeping (like a pin) — no need to ask first.
 

--- a/claude/commands/workspace.md
+++ b/claude/commands/workspace.md
@@ -26,7 +26,7 @@ tracker, scope confirmation, the hub-repo commit, and the cmux spawn.
 ### 1. Resolve the target → the workspace identifier
 
 A workspace targets **either a tracker issue or a PR/MR**. The chosen identifier is load-bearing:
-it becomes the worktree dir (`worktrees/<ID>/`), the manifest row, **and** the cmux workspace name —
+it becomes the workspace dir (`workspaces/<ID>/`), the manifest row, **and** the cmux workspace name —
 so it must be canonical and consistent. Pick the path by what `$ARGUMENTS` names:
 
 **A. Tracker issue** (`ABC-597`, …)
@@ -83,9 +83,9 @@ Capture `workspace_dir=` from the final stdout line. Idempotent — safe to re-r
 **restores** branches that already exist on the remote (the rebuild path).
 
 ### 5. Commit the manifest (hub repo)
-The engine wrote `worktrees/WORKSPACES.md` but did not commit:
+The engine wrote `workspaces/WORKSPACES.md` but did not commit:
 ```bash
-git -C "$HUB" add worktrees/WORKSPACES.md
+git -C "$HUB" add workspaces/WORKSPACES.md
 git -C "$HUB" commit -m "workspace: open <ID> (<repos>)"
 ```
 This is standing housekeeping (like a pin) — no need to ask first.
@@ -106,7 +106,7 @@ cmux-spawn-work \
   --cwd "<workspace_dir>" \
   --color "$color"
 ```
-The cmux name uses the **same identifier** as the worktree dir and manifest — they never diverge.
+The cmux name uses the **same identifier** as the workspace dir and manifest — they never diverge.
 This creates a cmux workspace cwd'd to the worktree with two splits — **Claude Code (left)** and a
 **terminal (right)**, tagged with the chosen distinct color — so the instance sees a fully isolated
 mini-workspace (shared memory, isolated history). Idempotent (re-running returns the existing

--- a/claude/commands/workspace.md
+++ b/claude/commands/workspace.md
@@ -1,0 +1,126 @@
+---
+description: >-
+  Instantiate a fully-isolated, per-issue mini-workspace: a worktree of the workspace repo with
+  nested worktrees of the in-scope submodules on the issue's feature branch, shared memory, a
+  tracked manifest row, and a cmux workspace cwd'd into it. Claude suggests the repo scope; you
+  confirm. Targets a tracker issue or a PR/MR.
+argument-hint: "<ISSUE-ID> (e.g. ABC-597) or a PR/MR (e.g. !37575 / #42 / MR-37575 / PR-42)"
+allowed-tools: Bash Read AskUserQuestion mcp__linear
+disable-model-invocation: true
+---
+Create an isolated per-issue workspace for: **$ARGUMENTS**
+
+This is the `/workspace` command of the worktree-focused workflow (see the workspace guide →
+"Per-issue worktree workspaces"). The engine is `workspace`; this command orchestrates the
+tracker, scope confirmation, the workspace-repo commit, and the cmux spawn.
+
+> **No `cd`, ever.** The engine (`workspace`, on PATH) self-anchors to the workspace root from
+> anywhere — it climbs out of any submodule before resolving. Resolve the root once for the
+> manifest commit and the spawn cwd, and use `git -C "$ROOT"`:
+> ```bash
+> ROOT="$(workspace root)"; echo "ROOT=$ROOT"
+> ```
+
+## Steps
+
+### 1. Resolve the target → the workspace identifier
+
+A workspace targets **either a tracker issue or a PR/MR**. The chosen identifier is load-bearing:
+it becomes the worktree dir (`worktrees/<ID>/`), the manifest row, **and** the cmux workspace name —
+so it must be canonical and consistent. Pick the path by what `$ARGUMENTS` names:
+
+**A. Tracker issue** (`ABC-597`, …)
+- Run `get_issue $ARGUMENTS` (Linear). Capture: `title`, `gitBranchName`, `url`, `priority`, and
+  the **description** (esp. any "Touch-points" / file paths).
+- The identifier is the issue key verbatim (`ABC-597`). `gitBranchName` is the canonical branch —
+  **use it verbatim** as `--branch`.
+- If the issue isn't found or the user passed a bare description, you may proceed ad-hoc: synthesize
+  a branch `feature/<lowercased-key-or-slug>` and a title. Confirm the branch name.
+
+**B. PR/MR** (`!37575`, `MR-37575`, `#42`, `PR-42`, a PR/MR URL, or "review the PR/MR for branch X")
+- **The identifier is always `PR-<N>` / `MR-<IID>`** — the forge's PR/MR number, never the branch
+  slug or an embedded tracker key. (This rule prevents drift: a branch like `srp/abc-73-flow` must
+  still produce `MR-37575`, not `ABC-73`.)
+- Resolve the PR/MR from the appropriate submodule (its remote determines forge/project), using
+  that submodule's forge CLI — `gh` for GitHub, `glab` for GitLab. Given a number directly, or
+  derive it from a branch, e.g.:
+  ```bash
+  # GitHub: branch → number
+  gh pr list --head "<branch>" --json number,title,headRefName
+  # GitLab: branch → IID
+  glab mr list --source-branch "<branch>"
+  ```
+- `--branch` is the PR/MR's source branch (use it verbatim). The **title** is the PR/MR title (trim
+  noise; drop a trailing `(!<IID> review)` / `(#<N> review)` — the `MR-`/`PR-` prefix carries it).
+
+### 2. Suggest the repo scope (Claude suggests → user decides)
+Infer which submodules are in scope from the issue/PR description + this conversation, then
+**always** confirm with an interactive checklist (the user is the decider). The candidate set is
+this workspace's submodules — list them with `workspace list` (or read `.gitmodules`); don't
+hardcode names. Map evidence → submodule using each repo's role (paths, languages, and naming in
+the description), and present the inferred set **pre-selected** via `AskUserQuestion` (multiSelect)
+with your reasoning in the question text. Default when nothing is clearly indicated: the primary
+application submodule.
+
+### 3. Surface integration-branch warnings
+For each chosen repo, the engine resolves the integration base from that submodule's branch **in the
+top-level checkout**. Run `workspace integration-branch <repo>` (or just let `create` print
+warnings) and **relay any warning** — e.g. "<repo> is on a feature branch, not its default". A
+warning usually means the one-time migration hasn't run yet, or feature work leaked into the main
+checkout; ask whether to proceed before creating.
+
+### 4. Create the workspace
+The engine's `--issue` flag is just the **workspace identifier** resolved in step 1 — pass the
+tracker key (`ABC-597`) or the `PR-<N>`/`MR-<IID>`, whichever applies:
+```bash
+workspace create \
+  --issue <ID> \
+  --branch <gitBranchName | PR/MR source branch> \
+  --repos <comma,separated,confirmed,repos> \
+  --title "<issue or PR/MR title>"
+```
+Capture `workspace_dir=` from the final stdout line. Idempotent — safe to re-run; it also
+**restores** branches that already exist on the remote (the rebuild path).
+
+### 5. Commit the manifest (workspace repo)
+The engine wrote `worktrees/WORKSPACES.md` but did not commit:
+```bash
+git -C "$ROOT" add worktrees/WORKSPACES.md
+git -C "$ROOT" commit -m "workspace: open <ID> (<repos>)"
+```
+This is standing housekeeping (like a pin) — no need to ask first.
+
+### 6. Spawn the cmux workspace (cwd'd into the worktree; claude + terminal splits)
+First pick a **distinct color** — one not already used by another workspace, so the sidebar stays
+legible — then spawn, using the absolute `workspace_dir` from step 4:
+```bash
+palette=("#1565C0" "#2E7D32" "#C62828" "#6A1B9A" "#EF6C00" "#00838F" "#AD1457" "#283593" "#9E9D24" "#00695C" "#455A64" "#5D4037")
+used="$(cmux --json list-workspaces | jq -r '.workspaces[].custom_color // empty')"
+color="${palette[0]}"   # fallback if all are taken
+for c in "${palette[@]}"; do
+  if ! grep -qiF "$c" <<<"$used"; then color="$c"; break; fi
+done
+
+cmux-spawn-work \
+  --name "<ID> · <title>" \
+  --cwd "<workspace_dir>" \
+  --color "$color"
+```
+The cmux name uses the **same identifier** as the worktree dir and manifest — they never diverge.
+This creates a cmux workspace cwd'd to the worktree with two splits — **Claude Code (left)** and a
+**terminal (right)**, tagged with the chosen distinct color — so the instance sees a fully isolated
+mini-workspace (shared memory, isolated history). Idempotent (re-running returns the existing
+workspace) and never steals focus. (`cmux-spawn-work` defaults to Blue if `--color` is omitted.)
+
+### 7. Report
+Summarize: workspace dir, the feature branch, which submodules are checked out, and the cmux
+workspace ref. Mention that `/workspace-sync <ID>` keeps it current and `/teardown <ID>` dismantles it.
+
+## Guardrails
+- **PR/MR targets are always `PR-<N>` / `MR-<IID>`** — derive the identifier from the forge number,
+  never from the branch slug or an embedded tracker key. Worktree dir, manifest row, and cmux name
+  all use this one identifier; they must never diverge.
+- **Confirm scope** — never skip the checklist; the user decides repos.
+- **Relay divergence warnings** — don't silently base a feature branch off stale feature work.
+- **Don't push anything** — `/workspace` only creates locally. Pushing is `/workspace-sync`.
+- **Idempotent** — re-running for an existing issue reuses/restores; it won't clobber work.

--- a/claude/commands/workspace.md
+++ b/claude/commands/workspace.md
@@ -10,8 +10,8 @@ disable-model-invocation: true
 ---
 Create an isolated per-issue workspace for: **$ARGUMENTS**
 
-This is the `/workspace` command of the worktree-focused workflow (see the workspace guide →
-"Per-issue worktree workspaces"). The engine is `workspace`; this command orchestrates the
+This is the `/workspace` command of the workspace workflow (see the workspace guide →
+"Per-issue workspaces"). The engine is `workspace`; this command orchestrates the
 tracker, scope confirmation, the hub-repo commit, and the cmux spawn.
 
 > **No `cd`, ever.** The engine (`workspace`, on PATH) self-anchors to the hub from anywhere — it

--- a/rcrc
+++ b/rcrc
@@ -1,4 +1,4 @@
-DOTFILES_DIRS="$HOME/Development/personal/workspace/modules/dotfiles"
+DOTFILES_DIRS="$HOME/Development/personal/hub/modules/dotfiles"
 COPY_ALWAYS="ssh/*"
 EXCLUDES="_assets bin terminfo .* README.md *:node_modules *:history *:cache Brewfile Brewfile.lock.json Yarnfile CargoFile config/opencode/agent/gworkspace.md"
 UNDOTTED="rubocop.yml tern-config"

--- a/scripts/cmux-spawn-work
+++ b/scripts/cmux-spawn-work
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# cmux-spawn-work — spawn a cmux workspace for a per-task worktree.
+#
+# Creates a workspace cwd'd to the given path with two splits: Claude Code (left, launched
+# via the workspace's initial command) and a terminal (right), tagged with --color (default
+# Blue; the /workspace command passes a distinct color it picks). Used by the `/workspace`
+# command after the worktrees are in place.
+#
+# Idempotent: re-running with the same --name returns the existing workspace instead of
+# creating a duplicate (and re-applies the color). Never steals focus (--focus false everywhere).
+#
+# Usage:
+#   cmux-spawn-work --name "dotfiles-zsh · refactor zsh config" \
+#                   --cwd /abs/path/to/worktrees/dotfiles-zsh [--command claude] [--color Blue]
+#
+# Output (stdout): one key=value line, e.g.
+#   workspace=workspace:21 status=created name="dotfiles-zsh · refactor zsh config"
+
+set -euo pipefail
+
+die() { printf 'cmux-spawn-work: error: %s\n' "$*" >&2; exit 1; }
+
+command -v cmux >/dev/null 2>&1 || die "cmux CLI not on PATH"
+command -v jq   >/dev/null 2>&1 || die "jq not on PATH (brew install jq)"
+
+name="" cwd="" cmd="claude" color="Blue"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --name)    name="$2";  shift 2;;
+    --cwd)     cwd="$2";   shift 2;;
+    --command) cmd="$2";   shift 2;;
+    --color)   color="$2"; shift 2;;
+    -h|--help) sed -n '2,17p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0;;
+    *) die "unknown flag: $1";;
+  esac
+done
+[ -n "$name" ] || die "--name is required"
+[ -n "$cwd" ]  || die "--cwd is required"
+[ -d "$cwd" ]  || die "--cwd does not exist: $cwd"
+
+# Match an existing workspace by title. Active workspace titles carry a live
+# activity-spinner glyph prefix, so we strip leading non-alphanumerics and then compare
+# the remainder to $name EXACTLY. A bare substring match would collide on prefix task IDs
+# (`ALEXJEU-9` matching an existing `ALEXJEU-90 · …`) and return the wrong workspace.
+find_ws() {
+  cmux --json list-workspaces 2>/dev/null \
+    | jq -r --arg n "$name" '.workspaces[] | select((.title | sub("^[^A-Za-z0-9]+"; "")) == $n) | .ref' \
+    | head -n1
+}
+
+# Tag the workspace with a consistent color (best-effort; never fail the spawn over it).
+set_color() { cmux workspace-action --action set-color --color "$color" --workspace "$1" >/dev/null 2>&1 || true; }
+
+existing="$(find_ws || true)"
+if [ -n "$existing" ]; then
+  set_color "$existing"
+  printf 'workspace=%s status=existing name=%q\n' "$existing" "$name"
+  exit 0
+fi
+
+# Create the workspace cwd'd to the worktree; --command launches Claude Code in the first
+# surface. new-workspace prints e.g. "OK workspace:21" — capture the ref from it.
+out="$(cmux new-workspace --name "$name" --cwd "$cwd" --command "$cmd" --focus false 2>&1)" \
+  || die "new-workspace failed: $out"
+ws="$(printf '%s' "$out" | grep -oE 'workspace:[0-9]+' | head -n1)"
+[ -n "$ws" ] || ws="$(find_ws || true)"
+[ -n "$ws" ] || die "could not resolve newly-created workspace (output: $out)"
+
+# Second split: a terminal to the right. New surfaces inherit the workspace cwd.
+cmux new-pane --type terminal --direction right --workspace "$ws" --focus false >/dev/null 2>&1 \
+  || die "new-pane (terminal) failed for $ws"
+
+set_color "$ws"
+
+printf 'workspace=%s status=created name=%q\n' "$ws" "$name"

--- a/scripts/workspace
+++ b/scripts/workspace
@@ -1,0 +1,434 @@
+#!/usr/bin/env bash
+# workspace — git/fs engine for per-task, fully-isolated "mini-workspace" worktrees.
+#
+# A per-task workspace is a worktree of THIS workspace repo (carrying CLAUDE.md,
+# .claude/, bin/, .cmux/, docs/, …) at  worktrees/<TASK>/ , with a git worktree of each
+# in-scope submodule nested inside it at  worktrees/<TASK>/modules/<repo>  on the task's
+# feature branch (mirroring the main checkout, where submodules live under modules/).
+# Submodule object stores are shared (no re-clone). The top-level repo's view stays a
+# clean, stable integration vantage point; feature work lives entirely in worktrees.
+#
+# This script is the deterministic plumbing. It does NOT:
+#   - commit the workspace repo  (the slash commands do that: manifest rows, pins)
+#   - talk to Linear or cmux      (the slash commands orchestrate those)
+# It is idempotent and never steals focus. All progress/warnings go to stderr;
+# capturable results go to stdout as `key=value` (create) or per-repo result lines.
+#
+# Integration branch resolution (the source of truth):
+#   integration_branch(repo) = the branch currently checked out for that submodule in
+#   the TOP-LEVEL workspace checkout, under modules/ (dotfiles→main, tao-te-ching→main, …).
+#   Nothing is hardcoded. Divergence from origin/HEAD is warned about, not blocked.
+#
+# Usage:
+#   workspace create  --task dotfiles-zsh --branch feature/dotfiles-zsh \
+#                     --repos dotfiles [--title "…"]
+#   workspace sync    --task dotfiles-zsh
+#   workspace update-modules [--repos dotfiles,tao-te-ching]
+#   workspace teardown --task dotfiles-zsh [--check]   (--check = dry-run safety report)
+#   workspace integration-branch dotfiles
+#   workspace list
+
+set -euo pipefail
+
+# ── locate the TRUE workspace root (the main worktree) ────────────────────────
+# This engine lives on PATH (~/.scripts → modules/dotfiles/scripts/), NOT inside the
+# workspace repo, so it can't self-anchor from its own location. Resolve from the caller's
+# cwd instead:
+#   1. honor an explicit $WORKSPACE_ROOT (export to override; handy for tests);
+#   2. else climb out of any submodule to the top superproject, then take the parent of
+#      that repo's git COMMON dir. From a linked worktree this still lands on the main
+#      checkout (worktrees share the main .git); climbing first sidesteps the .git/modules
+#      trap that a bare --git-common-dir hits inside a submodule;
+#   3. else fall back to the canonical default path.
+DEFAULT_WORKSPACE_ROOT="$HOME/Development/personal/workspace"
+resolve_workspace_root() {
+  local base sp common
+  base="$PWD"
+  while sp="$(git -C "$base" rev-parse --show-superproject-working-tree 2>/dev/null)" && [ -n "$sp" ]; do
+    base="$sp"
+  done
+  if common="$(git -C "$base" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)"; then
+    dirname "$common"; return 0
+  fi
+  printf '%s' "$DEFAULT_WORKSPACE_ROOT"
+}
+WORKSPACE_ROOT="${WORKSPACE_ROOT:-$(resolve_workspace_root)}"
+
+KNOWN_SUBMODULES="dotfiles tao-te-ching zero-based-budget"
+# Submodules are grouped under this dir, both in the main checkout and inside each
+# per-task worktree. Repo identifiers (in --repos and the manifest) stay bare names;
+# this prefix locates them on disk. To flatten back to the root, set MODULES_DIR="".
+MODULES_DIR="modules"
+MANIFEST="$WORKSPACE_ROOT/worktrees/WORKSPACES.md"
+
+# Path to a submodule's checkout, given a base dir (the main root or a worktree dir).
+submodule_path() { if [ -n "$MODULES_DIR" ]; then printf '%s/%s/%s' "$1" "$MODULES_DIR" "$2"; else printf '%s/%s' "$1" "$2"; fi; }
+
+# ── output helpers (info/warn/die → stderr; emit → stdout) ────────────────────
+info() { printf '  %s\n' "$*" >&2; }
+warn() { printf 'workspace: warning: %s\n' "$*" >&2; }
+die()  { printf 'workspace: error: %s\n' "$*" >&2; exit 1; }
+emit() { printf '%s\n' "$*"; }
+
+is_known_submodule() {
+  case " $KNOWN_SUBMODULES " in *" $1 "*) return 0;; *) return 1;; esac
+}
+
+# Claude Code keys per-project memory/history by the absolute cwd path with '/' → '-'.
+path_to_project_key() { printf '%s' "$1" | sed 's#/#-#g'; }
+
+# Is there a git worktree (workspace or submodule) materialized at this path?
+worktree_present() { [ -e "$1/.git" ]; }
+
+# ── integration branch resolution ─────────────────────────────────────────────
+integration_branch() {
+  local repo="$1" rd br def
+  rd="$(submodule_path "$WORKSPACE_ROOT" "$repo")"
+  [ -d "$rd" ] || die "unknown submodule path: $rd"
+  br="$(git -C "$rd" branch --show-current 2>/dev/null || true)"
+  def="$(git -C "$rd" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##' || true)"
+  if [ -z "$br" ]; then
+    [ -n "$def" ] || die "$repo is detached and origin/HEAD is unknown — cannot resolve integration branch"
+    warn "$repo is in detached HEAD; falling back to its default branch '$def'"
+    br="$def"
+  elif [ -n "$def" ] && [ "$br" != "$def" ]; then
+    warn "$repo is on '$br' but its default is '$def' — using '$br' as the integration base (move feature work into a worktree if this is stale work in the main checkout)"
+  fi
+  printf '%s' "$br"
+}
+
+# ── manifest (worktrees/WORKSPACES.md) ────────────────────────────────────────
+manifest_ensure() {
+  mkdir -p "$(dirname "$MANIFEST")"
+  [ -f "$MANIFEST" ] && return 0
+  cat > "$MANIFEST" <<'EOF'
+# Workspaces Manifest
+
+Reconstruction recipe for the per-task worktrees under `worktrees/`. Each row is enough
+to rebuild a `worktrees/<TASK>/` mini-workspace on a fresh clone: re-create the workspace
+worktree, then a worktree of each listed repo on the task's feature branch (which
+`/workspace-sync` has pushed to the submodule remotes). The checkouts themselves are
+gitignored; this file is tracked. Managed by `/workspace` and `/teardown` (`bin/workspace`).
+
+| Task | Title | Repos | Branch | Opened |
+|------|-------|-------|--------|--------|
+EOF
+}
+
+manifest_remove() {
+  local task="$1" tmp
+  [ -f "$MANIFEST" ] || return 0
+  tmp="$(mktemp)"
+  # Drop the data row whose first column (Task) equals $task EXACTLY. Compared as a literal
+  # field value (not a regex), so task names with regex metacharacters — `dotfiles.v2`, `a+b`
+  # — match only their own row instead of matching/missing the wrong one.
+  awk -F'|' -v t="$task" '{ f=$2; gsub(/^[ \t]+|[ \t]+$/, "", f); if (f != t) print }' "$MANIFEST" > "$tmp"
+  mv "$tmp" "$MANIFEST"
+}
+
+manifest_upsert() {
+  local task="$1" title="$2" repos="$3" branch="$4" opened
+  opened="$(date +%Y-%m-%d)"
+  manifest_ensure
+  manifest_remove "$task"
+  printf '| %s | %s | %s | %s | %s |\n' "$task" "${title:-—}" "$repos" "$branch" "$opened" >> "$MANIFEST"
+}
+
+# ── memory symlink (share canonical memory; history stays per-task) ───────────
+setup_memory_symlink() {
+  local ws_dir="$1" projects_dir canonical_memory per_task_dir link
+  projects_dir="$HOME/.claude/projects"
+  canonical_memory="$projects_dir/$(path_to_project_key "$WORKSPACE_ROOT")/memory"
+  per_task_dir="$projects_dir/$(path_to_project_key "$ws_dir")"
+  link="$per_task_dir/memory"
+  mkdir -p "$canonical_memory" "$per_task_dir"
+  if [ -L "$link" ]; then
+    info "memory: symlink already present"
+  elif [ -e "$link" ]; then
+    warn "memory: $link exists and is not a symlink — leaving as-is (history will be isolated but memory not shared)"
+  else
+    ln -s "$canonical_memory" "$link"
+    info "memory: linked $link → canonical (shared facts, isolated history)"
+  fi
+}
+
+# ── create ────────────────────────────────────────────────────────────────────
+cmd_create() {
+  local task="" branch="" repos="" title=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --task)   task="$2";   shift 2;;
+      --branch) branch="$2"; shift 2;;
+      --repos)  repos="$2";  shift 2;;
+      --title)  title="$2";  shift 2;;
+      *) die "create: unknown flag $1";;
+    esac
+  done
+  [ -n "$task" ]   || die "create requires --task (e.g. dotfiles-zsh)"
+  [ -n "$branch" ] || die "create requires --branch (e.g. feature/dotfiles-zsh)"
+  [ -n "$repos" ]  || die "create requires --repos (comma-separated; e.g. dotfiles,tao-te-ching)"
+
+  local ws_dir="$WORKSPACE_ROOT/worktrees/$task"
+  local -a repo_arr
+  IFS=',' read -ra repo_arr <<< "$repos"
+  local repo
+  for repo in "${repo_arr[@]}"; do
+    is_known_submodule "$repo" || die "create: '$repo' is not a known submodule ($KNOWN_SUBMODULES)"
+  done
+
+  # 1. workspace-repo worktree (detached @ current workspace HEAD — scaffolding only, no pins)
+  if worktree_present "$ws_dir"; then
+    info "workspace worktree already at $ws_dir"
+  else
+    info "creating workspace worktree at worktrees/$task (detached)"
+    git -C "$WORKSPACE_ROOT" worktree add --detach "$ws_dir" HEAD >/dev/null
+  fi
+
+  # 2. a worktree of each in-scope submodule, on the task's feature branch
+  for repo in "${repo_arr[@]}"; do
+    local repo_path target ib
+    repo_path="$(submodule_path "$WORKSPACE_ROOT" "$repo")"
+    target="$(submodule_path "$ws_dir" "$repo")"
+    mkdir -p "$(dirname "$target")"   # ensure worktrees/<TASK>/modules/ exists
+    ib="$(integration_branch "$repo")"
+    git -C "$repo_path" fetch origin "$ib" --quiet 2>/dev/null || warn "$repo: fetch origin/$ib failed (offline?) — proceeding with local refs"
+    if worktree_present "$target"; then
+      info "$repo: worktree already present"
+    elif git -C "$repo_path" show-ref --verify --quiet "refs/heads/$branch"; then
+      info "$repo: attaching existing local branch $branch"
+      # An existing local branch may already be checked out in another worktree, in which
+      # case `worktree add` fails ("already checked out at …"). Without this guard, set -e
+      # would abort cmd_create mid-loop, leaving a half-built workspace. Skip this repo with
+      # a clear, actionable diagnostic instead — create is idempotent, so re-run once resolved.
+      if ! git -C "$repo_path" worktree add "$target" "$branch" >/dev/null 2>&1; then
+        warn "$repo: cannot attach branch '$branch' — it may already be checked out in another worktree (see: git -C \"$repo_path\" worktree list). Skipping $repo; resolve, then re-run /workspace $task."
+        continue
+      fi
+    elif git -C "$repo_path" ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+      info "$repo: restoring branch $branch from origin (tracking)"
+      git -C "$repo_path" worktree add --track -b "$branch" "$target" "origin/$branch" >/dev/null
+    else
+      info "$repo: new branch $branch off origin/$ib"
+      git -C "$repo_path" worktree add -b "$branch" "$target" "origin/$ib" >/dev/null
+    fi
+
+    # Initialize the worktree's scaffolding (env files, symlinks, history files) if the
+    # repo ships a bin/worktree-init. The post-checkout hook is supposed to do this on
+    # `git worktree add`, but it doesn't fire reliably here — so invoke it directly.
+    # Idempotent and repo-guarded: only repos that ship bin/worktree-init get it.
+    if [ -x "$target/bin/worktree-init" ]; then
+      info "$repo: running bin/worktree-init (env files, symlinks)"
+      ( cd "$target" && bin/worktree-init >/dev/null ) || warn "$repo: bin/worktree-init failed (continuing)"
+    fi
+  done
+
+  # 3. share memory (must exist before Claude launches in the workspace)
+  setup_memory_symlink "$ws_dir"
+
+  # 4. record in the reconstruction manifest (caller commits it)
+  manifest_upsert "$task" "$title" "$repos" "$branch"
+  info "manifest: recorded $task (caller should commit worktrees/WORKSPACES.md)"
+
+  emit "workspace_dir=$ws_dir task=$task repos=$repos branch=$branch status=ready"
+}
+
+# ── sync (merge integration branch in, push; report conflicts) ────────────────
+cmd_sync() {
+  local task=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --task) task="$2"; shift 2;;
+      *) die "sync: unknown flag $1";;
+    esac
+  done
+  [ -n "$task" ] || die "sync requires --task"
+  local ws_dir="$WORKSPACE_ROOT/worktrees/$task"
+  worktree_present "$ws_dir" || die "no workspace at $ws_dir (run /workspace $task first)"
+
+  local repo any=0 conflicts=0
+  for repo in $KNOWN_SUBMODULES; do
+    local rd
+    rd="$(submodule_path "$ws_dir" "$repo")"
+    worktree_present "$rd" || continue
+    any=1
+    local ib cur
+    ib="$(integration_branch "$repo")"
+    cur="$(git -C "$rd" branch --show-current 2>/dev/null || true)"
+    # Detached HEAD → empty $cur; the no-upstream push below would become the invalid
+    # `git push -u origin ""`. Bail early with a clear diagnostic instead.
+    if [ -z "$cur" ]; then
+      emit "ERROR $repo: detached HEAD in worktrees/$task/$repo — checkout the feature branch before syncing"; conflicts=1; continue
+    fi
+    git -C "$rd" fetch origin "$ib" --quiet 2>/dev/null || { emit "ERROR $repo: fetch origin/$ib failed"; conflicts=1; continue; }
+    if git -C "$rd" merge --no-edit "origin/$ib" >/dev/null 2>&1; then
+      if git -C "$rd" rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1; then
+        if git -C "$rd" push >/dev/null 2>&1; then
+          emit "OK $repo: merged origin/$ib into $cur, pushed"
+        else
+          emit "ERROR $repo: merged origin/$ib but push failed (resolve in worktrees/$task/$repo)"; conflicts=1
+        fi
+      elif git -C "$rd" push -u origin "$cur" >/dev/null 2>&1; then
+        emit "OK $repo: merged origin/$ib into $cur, pushed (set upstream)"
+      else
+        emit "ERROR $repo: merged origin/$ib but initial push failed (resolve in worktrees/$task/$repo)"; conflicts=1
+      fi
+    else
+      emit "CONFLICT $repo: merge of origin/$ib into $cur conflicts — resolve in worktrees/$task/$repo, then re-run sync"
+      conflicts=1
+    fi
+  done
+  [ "$any" = 1 ] || die "no submodule worktrees found under $ws_dir"
+  return "$conflicts"
+}
+
+# ── update-modules (fast-forward main-checkout submodules; caller pins) ───────
+cmd_update_modules() {
+  local repos=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --repos) repos="$2"; shift 2;;
+      *) die "update-modules: unknown flag $1";;
+    esac
+  done
+  local -a repo_arr
+  if [ -n "$repos" ]; then
+    IFS=',' read -ra repo_arr <<< "$repos"
+  else
+    read -ra repo_arr <<< "$KNOWN_SUBMODULES"
+  fi
+
+  local repo moved=""
+  for repo in "${repo_arr[@]}"; do
+    is_known_submodule "$repo" || die "update-modules: '$repo' is not a known submodule"
+    local rd ib before after
+    rd="$(submodule_path "$WORKSPACE_ROOT" "$repo")"
+    ib="$(integration_branch "$repo")"
+    before="$(git -C "$rd" rev-parse --short HEAD)"
+    git -C "$rd" fetch origin "$ib" --quiet 2>/dev/null || { emit "ERROR $repo: fetch origin/$ib failed"; continue; }
+    if git -C "$rd" merge --ff-only "origin/$ib" >/dev/null 2>&1; then
+      after="$(git -C "$rd" rev-parse --short HEAD)"
+      if [ "$before" != "$after" ]; then
+        emit "MOVED $repo: $before → $after ($ib)"; moved="$moved $repo"
+      else
+        emit "OK $repo: already current ($ib @ $after)"
+      fi
+    else
+      emit "SKIP $repo: origin/$ib is not a fast-forward from $before (diverged or local commits on '$ib') — resolve manually"
+    fi
+  done
+  # tell the caller which gitlinks to stage+commit as pins
+  [ -n "$moved" ] && emit "PIN:${moved# }"
+  return 0
+}
+
+# ── teardown (remove worktrees, prune, drop manifest row) ─────────────────────
+cmd_teardown() {
+  local task="" check=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --task)  task="$2"; shift 2;;
+      --check) check=1; shift;;
+      *) die "teardown: unknown flag $1";;
+    esac
+  done
+  [ -n "$task" ] || die "teardown requires --task"
+  local ws_dir="$WORKSPACE_ROOT/worktrees/$task"
+
+  # ── --check: dry-run safety report. Surfaces uncommitted + unpushed work per
+  # submodule worktree and changes NOTHING. Lets /teardown run the safety check
+  # via the (cwd-independent) engine instead of a fragile shell glob. Final line
+  # is `check=clean|dirty task=<TASK>` for the caller to branch on. ────────────
+  if [ "$check" = 1 ]; then
+    worktree_present "$ws_dir" || die "no workspace at $ws_dir (nothing to tear down)"
+    local repo any=0 dirty=0
+    for repo in $KNOWN_SUBMODULES; do
+      local rd
+      rd="$(submodule_path "$ws_dir" "$repo")"
+      worktree_present "$rd" || continue
+      any=1
+      local st unpushed cur no_upstream=0 ib
+      cur="$(git -C "$rd" branch --show-current 2>/dev/null || true)"
+      st="$(git -C "$rd" status --porcelain 2>/dev/null || true)"
+      if git -C "$rd" rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1; then
+        unpushed="$(git -C "$rd" log --oneline '@{u}..' 2>/dev/null || true)"
+      else
+        # No upstream set yet ≠ dirty. Approximate "unpushed work" as commits unique to this
+        # branch vs its integration base, so a freshly-created branch with zero commits beyond
+        # base isn't flagged dirty (and blocked from teardown) merely for lacking an upstream.
+        no_upstream=1
+        ib="$(integration_branch "$repo")"
+        unpushed="$(git -C "$rd" log --oneline "origin/$ib.." 2>/dev/null || true)"
+      fi
+      [ -n "$st$unpushed" ] && dirty=1
+      emit "REPO $repo (branch ${cur:-detached})"
+      if [ -n "$st" ]; then emit "  uncommitted:"; emit "$st"; else emit "  uncommitted: none"; fi
+      if [ -n "$unpushed" ]; then
+        emit "  unpushed:"; emit "$unpushed"
+        [ "$no_upstream" = 1 ] && emit "  (no upstream set — run /workspace-sync $task to push)"
+      elif [ "$no_upstream" = 1 ]; then
+        emit "  unpushed: none (no upstream set yet; no commits beyond origin/${ib})"
+      else
+        emit "  unpushed: none"
+      fi
+    done
+    [ "$any" = 1 ] || emit "(no submodule worktrees under $ws_dir)"
+    if [ "$dirty" = 1 ]; then emit "check=dirty task=$task"; else emit "check=clean task=$task"; fi
+    return 0
+  fi
+
+  local repo
+  for repo in $KNOWN_SUBMODULES; do
+    local target repo_path
+    target="$(submodule_path "$ws_dir" "$repo")"
+    repo_path="$(submodule_path "$WORKSPACE_ROOT" "$repo")"
+    if worktree_present "$target"; then
+      info "removing $repo worktree"
+      git -C "$repo_path" worktree remove --force "$target" || warn "$repo: worktree remove failed for $target"
+    fi
+  done
+  if worktree_present "$ws_dir"; then
+    info "removing workspace worktree"
+    git -C "$WORKSPACE_ROOT" worktree remove --force "$ws_dir" || warn "workspace: worktree remove failed for $ws_dir"
+  fi
+  # prune dangling worktree admin entries
+  git -C "$WORKSPACE_ROOT" worktree prune 2>/dev/null || true
+  for repo in $KNOWN_SUBMODULES; do
+    git -C "$(submodule_path "$WORKSPACE_ROOT" "$repo")" worktree prune 2>/dev/null || true
+  done
+  # NOTE: deliberately leave the per-task memory symlink + history dir under
+  # ~/.claude/projects untouched (no rm under $HOME). The symlink points at the
+  # persistent canonical memory and is harmless.
+
+  manifest_remove "$task"
+  info "manifest: dropped $task (caller should commit worktrees/WORKSPACES.md)"
+  emit "torn_down=$task status=removed"
+}
+
+# ── list ──────────────────────────────────────────────────────────────────────
+cmd_list() {
+  if [ -f "$MANIFEST" ]; then
+    cat "$MANIFEST"
+  else
+    emit "(no manifest yet)"
+  fi
+  emit ""
+  emit "Workspace worktrees:"
+  git -C "$WORKSPACE_ROOT" worktree list
+}
+
+# ── dispatch ──────────────────────────────────────────────────────────────────
+usage() { sed -n '2,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 2; }
+
+[ $# -gt 0 ] || usage
+cmd="$1"; shift
+case "$cmd" in
+  create)               cmd_create "$@";;
+  sync)                 cmd_sync "$@";;
+  update-modules)       cmd_update_modules "$@";;
+  teardown)             cmd_teardown "$@";;
+  integration-branch)   [ $# -eq 1 ] || die "integration-branch requires exactly one <repo>"; integration_branch "$1"; printf '\n';;
+  root)                 emit "$WORKSPACE_ROOT";;
+  list)                 cmd_list;;
+  -h|--help|help)       usage;;
+  *) die "unknown command: $cmd (expected: create|sync|update-modules|teardown|integration-branch|root|list)";;
+esac

--- a/scripts/workspace
+++ b/scripts/workspace
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 # workspace — git/fs engine for per-task, fully-isolated "mini-workspace" worktrees.
 #
-# A per-task workspace is a worktree of THIS workspace repo (carrying CLAUDE.md,
+# Terms: the HUB is the top-level checkout (the stable integration view containing modules/
+# and worktrees/); a WORKSPACE is a per-task worktree of the hub. The hub repo is the git
+# repo the hub is a checkout of.
+#
+# A per-task workspace is a worktree of THIS hub repo (carrying CLAUDE.md,
 # .claude/, bin/, .cmux/, docs/, …) at  worktrees/<TASK>/ , with a git worktree of each
 # in-scope submodule nested inside it at  worktrees/<TASK>/modules/<repo>  on the task's
 # feature branch (mirroring the main checkout, where submodules live under modules/).
@@ -9,13 +13,13 @@
 # clean, stable integration vantage point; feature work lives entirely in worktrees.
 #
 # This script is the deterministic plumbing. It does NOT:
-#   - commit the workspace repo  (the slash commands do that: manifest rows, pins)
+#   - commit the hub repo        (the slash commands do that: manifest rows, pins)
 #   - talk to Linear or cmux      (the slash commands orchestrate those)
 # It is idempotent and never steals focus. All progress/warnings go to stderr;
 # capturable results go to stdout as `key=value` (create) or per-repo result lines.
 #
-# The set of submodules is discovered from the root's .gitmodules, and the root from the
-# caller's cwd — nothing is workspace-specific, so the same engine drives every workspace.
+# The set of submodules is discovered from the hub's .gitmodules, and the hub from the
+# caller's cwd — nothing is hub-specific, so the same engine drives every hub.
 #
 # Integration branch resolution (the source of truth):
 #   integration_branch(repo) = the branch currently checked out for that submodule in
@@ -32,18 +36,18 @@
 
 set -euo pipefail
 
-# ── locate the TRUE workspace root (the main worktree) ────────────────────────
+# ── locate the TRUE hub (the top-level checkout / main worktree) ──────────────
 # This engine lives on PATH (~/.scripts → modules/dotfiles/scripts/) and is shared across
 # every per-task workspace, NOT inside any one repo — so it can't self-anchor from its own
 # location, and nothing about the root is hardcoded. Resolve from the caller's cwd instead:
-#   1. honor an explicit $WORKSPACE_ROOT (export to override; handy for tests);
+#   1. honor an explicit $WORKSPACE_HUB (export to override; handy for tests);
 #   2. else climb out of any submodule to the top superproject, then take the parent of
 #      that repo's git COMMON dir. From a linked worktree this still lands on the main
 #      checkout (worktrees share the main .git); climbing first sidesteps the .git/modules
 #      trap that a bare --git-common-dir hits inside a submodule.
-# If neither yields a root (run from outside any checkout), die with a clear message rather
-# than guessing a workspace-specific default.
-resolve_workspace_root() {
+# If neither yields a hub (run from outside any checkout), die with a clear message rather
+# than guessing a default.
+resolve_hub() {
   local base sp common
   base="$PWD"
   while sp="$(git -C "$base" rev-parse --show-superproject-working-tree 2>/dev/null)" && [ -n "$sp" ]; do
@@ -54,20 +58,20 @@ resolve_workspace_root() {
   fi
   return 0   # print nothing → caller dies with a clear message
 }
-WORKSPACE_ROOT="${WORKSPACE_ROOT:-$(resolve_workspace_root)}"
-[ -n "$WORKSPACE_ROOT" ] || { printf 'workspace: error: cannot resolve the workspace root from %s — cd into a workspace checkout or export $WORKSPACE_ROOT\n' "$PWD" >&2; exit 1; }
+HUB="${WORKSPACE_HUB:-$(resolve_hub)}"
+[ -n "$HUB" ] || { printf 'workspace: error: cannot resolve the hub from %s — cd into a hub checkout or export $WORKSPACE_HUB\n' "$PWD" >&2; exit 1; }
 
 # Submodules are grouped under this dir, both in the main checkout and inside each per-task
 # worktree. Repo identifiers (in --repos and the manifest) stay bare names; this prefix
 # locates them on disk. To flatten back to the root, set MODULES_DIR="".
 MODULES_DIR="modules"
-MANIFEST="$WORKSPACE_ROOT/worktrees/WORKSPACES.md"
+MANIFEST="$HUB/worktrees/WORKSPACES.md"
 
 # Known submodules are DISCOVERED from the root's .gitmodules (repo id = path basename),
 # so the engine adapts to whatever workspace it runs in, with zero hardcoding.
 # Override with $WORKSPACE_SUBMODULES (space-separated) if ever needed.
 discover_submodules() {
-  local gm="$WORKSPACE_ROOT/.gitmodules" p
+  local gm="$HUB/.gitmodules" p
   [ -f "$gm" ] || return 0
   git config -f "$gm" --get-regexp '^submodule\..*\.path$' 2>/dev/null \
     | awk '{print $2}' | while IFS= read -r p; do [ -n "$p" ] && basename "$p"; done
@@ -97,7 +101,7 @@ worktree_present() { [ -e "$1/.git" ]; }
 # ── integration branch resolution ─────────────────────────────────────────────
 integration_branch() {
   local repo="$1" rd br def
-  rd="$(submodule_path "$WORKSPACE_ROOT" "$repo")"
+  rd="$(submodule_path "$HUB" "$repo")"
   [ -d "$rd" ] || die "unknown submodule path: $rd"
   br="$(git -C "$rd" branch --show-current 2>/dev/null || true)"
   def="$(git -C "$rd" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##' || true)"
@@ -152,7 +156,7 @@ manifest_upsert() {
 setup_memory_symlink() {
   local ws_dir="$1" projects_dir canonical_memory per_task_dir link
   projects_dir="$HOME/.claude/projects"
-  canonical_memory="$projects_dir/$(path_to_project_key "$WORKSPACE_ROOT")/memory"
+  canonical_memory="$projects_dir/$(path_to_project_key "$HUB")/memory"
   per_task_dir="$projects_dir/$(path_to_project_key "$ws_dir")"
   link="$per_task_dir/memory"
   mkdir -p "$canonical_memory" "$per_task_dir"
@@ -182,7 +186,7 @@ cmd_create() {
   [ -n "$branch" ] || die "create requires --branch (e.g. feature/dotfiles-zsh)"
   [ -n "$repos" ]  || die "create requires --repos (comma-separated; e.g. dotfiles,tao-te-ching)"
 
-  local ws_dir="$WORKSPACE_ROOT/worktrees/$task"
+  local ws_dir="$HUB/worktrees/$task"
   local -a repo_arr
   IFS=',' read -ra repo_arr <<< "$repos"
   local repo
@@ -195,13 +199,13 @@ cmd_create() {
     info "workspace worktree already at $ws_dir"
   else
     info "creating workspace worktree at worktrees/$task (detached)"
-    git -C "$WORKSPACE_ROOT" worktree add --detach "$ws_dir" HEAD >/dev/null
+    git -C "$HUB" worktree add --detach "$ws_dir" HEAD >/dev/null
   fi
 
   # 2. a worktree of each in-scope submodule, on the task's feature branch
   for repo in "${repo_arr[@]}"; do
     local repo_path target ib
-    repo_path="$(submodule_path "$WORKSPACE_ROOT" "$repo")"
+    repo_path="$(submodule_path "$HUB" "$repo")"
     target="$(submodule_path "$ws_dir" "$repo")"
     mkdir -p "$(dirname "$target")"   # ensure worktrees/<TASK>/modules/ exists
     ib="$(integration_branch "$repo")"
@@ -256,7 +260,7 @@ cmd_sync() {
     esac
   done
   [ -n "$task" ] || die "sync requires --task"
-  local ws_dir="$WORKSPACE_ROOT/worktrees/$task"
+  local ws_dir="$HUB/worktrees/$task"
   worktree_present "$ws_dir" || die "no workspace at $ws_dir (run /workspace $task first)"
 
   local repo any=0 conflicts=0
@@ -315,7 +319,7 @@ cmd_update_modules() {
   for repo in "${repo_arr[@]}"; do
     is_known_submodule "$repo" || die "update-modules: '$repo' is not a known submodule"
     local rd ib before after
-    rd="$(submodule_path "$WORKSPACE_ROOT" "$repo")"
+    rd="$(submodule_path "$HUB" "$repo")"
     ib="$(integration_branch "$repo")"
     before="$(git -C "$rd" rev-parse --short HEAD)"
     git -C "$rd" fetch origin "$ib" --quiet 2>/dev/null || { emit "ERROR $repo: fetch origin/$ib failed"; continue; }
@@ -346,7 +350,7 @@ cmd_teardown() {
     esac
   done
   [ -n "$task" ] || die "teardown requires --task"
-  local ws_dir="$WORKSPACE_ROOT/worktrees/$task"
+  local ws_dir="$HUB/worktrees/$task"
 
   # ── --check: dry-run safety report. Surfaces uncommitted + unpushed work per
   # submodule worktree and changes NOTHING. Lets /teardown run the safety check
@@ -394,7 +398,7 @@ cmd_teardown() {
   for repo in $KNOWN_SUBMODULES; do
     local target repo_path
     target="$(submodule_path "$ws_dir" "$repo")"
-    repo_path="$(submodule_path "$WORKSPACE_ROOT" "$repo")"
+    repo_path="$(submodule_path "$HUB" "$repo")"
     if worktree_present "$target"; then
       info "removing $repo worktree"
       git -C "$repo_path" worktree remove --force "$target" || warn "$repo: worktree remove failed for $target"
@@ -402,12 +406,12 @@ cmd_teardown() {
   done
   if worktree_present "$ws_dir"; then
     info "removing workspace worktree"
-    git -C "$WORKSPACE_ROOT" worktree remove --force "$ws_dir" || warn "workspace: worktree remove failed for $ws_dir"
+    git -C "$HUB" worktree remove --force "$ws_dir" || warn "workspace: worktree remove failed for $ws_dir"
   fi
   # prune dangling worktree admin entries
-  git -C "$WORKSPACE_ROOT" worktree prune 2>/dev/null || true
+  git -C "$HUB" worktree prune 2>/dev/null || true
   for repo in $KNOWN_SUBMODULES; do
-    git -C "$(submodule_path "$WORKSPACE_ROOT" "$repo")" worktree prune 2>/dev/null || true
+    git -C "$(submodule_path "$HUB" "$repo")" worktree prune 2>/dev/null || true
   done
   # NOTE: deliberately leave the per-task memory symlink + history dir under
   # ~/.claude/projects untouched (no rm under $HOME). The symlink points at the
@@ -427,7 +431,7 @@ cmd_list() {
   fi
   emit ""
   emit "Workspace worktrees:"
-  git -C "$WORKSPACE_ROOT" worktree list
+  git -C "$HUB" worktree list
 }
 
 # ── dispatch ──────────────────────────────────────────────────────────────────
@@ -441,8 +445,8 @@ case "$cmd" in
   update-modules)       cmd_update_modules "$@";;
   teardown)             cmd_teardown "$@";;
   integration-branch)   [ $# -eq 1 ] || die "integration-branch requires exactly one <repo>"; integration_branch "$1"; printf '\n';;
-  root)                 emit "$WORKSPACE_ROOT";;
+  hub|root)             emit "$HUB";;
   list)                 cmd_list;;
   -h|--help|help)       usage;;
-  *) die "unknown command: $cmd (expected: create|sync|update-modules|teardown|integration-branch|root|list)";;
+  *) die "unknown command: $cmd (expected: create|sync|update-modules|teardown|integration-branch|hub|list)";;
 esac

--- a/scripts/workspace
+++ b/scripts/workspace
@@ -19,12 +19,12 @@
 # It is idempotent and never steals focus. All progress/warnings go to stderr;
 # capturable results go to stdout as `key=value` (create) or per-repo result lines.
 #
-# The set of submodules is discovered from the hub's .gitmodules, and the hub from the
+# The set of submodules is discovered from the hub root's .gitmodules, and the hub from the
 # caller's cwd — nothing is hub-specific, so the same engine drives every hub.
 #
 # Integration branch resolution (the source of truth):
 #   integration_branch(repo) = the branch currently checked out for that submodule in
-#   the TOP-LEVEL workspace checkout, under modules/ (e.g. dotfiles→main).
+#   the hub checkout, under modules/ (e.g. dotfiles→main).
 #   Nothing is hardcoded. Divergence from origin/HEAD is warned about, not blocked.
 #
 # Usage (--task and --issue are interchangeable):
@@ -68,8 +68,8 @@ HUB="${WORKSPACE_HUB:-$(resolve_hub)}"
 MODULES_DIR="modules"
 MANIFEST="$HUB/worktrees/WORKSPACES.md"
 
-# Known submodules are DISCOVERED from the root's .gitmodules (repo id = path basename),
-# so the engine adapts to whatever workspace it runs in, with zero hardcoding.
+# Known submodules are DISCOVERED from the hub root's .gitmodules (repo id = path basename),
+# so the engine adapts to whatever hub it runs in, with zero hardcoding.
 # Override with $WORKSPACE_SUBMODULES (space-separated) if ever needed.
 discover_submodules() {
   local gm="$HUB/.gitmodules" p

--- a/scripts/workspace
+++ b/scripts/workspace
@@ -2,13 +2,13 @@
 # workspace — git/fs engine for per-task, fully-isolated workspaces.
 #
 # Terms: the HUB is the top-level checkout (the stable integration view containing modules/
-# and worktrees/); a WORKSPACE is the per-task, isolated environment for one issue/PR, and
+# and workspaces/); a WORKSPACE is the per-task, isolated environment for one issue/PR, and
 # WORKTREE is the git mechanism it's built from. The hub repo is the git repo the hub is a
 # checkout of.
 #
 # A per-task workspace is materialized as a git worktree of THIS hub repo (carrying CLAUDE.md,
-# .claude/, bin/, .cmux/, docs/, …) at  worktrees/<TASK>/ , with a git worktree of each
-# in-scope submodule nested inside it at  worktrees/<TASK>/modules/<repo>  on the task's
+# .claude/, bin/, .cmux/, docs/, …) at  workspaces/<TASK>/ , with a git worktree of each
+# in-scope submodule nested inside it at  workspaces/<TASK>/modules/<repo>  on the task's
 # feature branch (mirroring the hub, where submodules live under modules/). Submodule object
 # stores are shared (no re-clone). The hub's view stays a clean, stable integration vantage
 # point; feature work lives entirely in worktrees.
@@ -66,7 +66,7 @@ HUB="${WORKSPACE_HUB:-$(resolve_hub)}"
 # worktree. Repo identifiers (in --repos and the manifest) stay bare names; this prefix
 # locates them on disk. To flatten back to the root, set MODULES_DIR="".
 MODULES_DIR="modules"
-MANIFEST="$HUB/worktrees/WORKSPACES.md"
+MANIFEST="$HUB/workspaces/WORKSPACES.md"
 
 # Known submodules are DISCOVERED from the hub root's .gitmodules (repo id = path basename),
 # so the engine adapts to whatever hub it runs in, with zero hardcoding.
@@ -116,15 +116,15 @@ integration_branch() {
   printf '%s' "$br"
 }
 
-# ── manifest (worktrees/WORKSPACES.md) ────────────────────────────────────────
+# ── manifest (workspaces/WORKSPACES.md) ────────────────────────────────────────
 manifest_ensure() {
   mkdir -p "$(dirname "$MANIFEST")"
   [ -f "$MANIFEST" ] && return 0
   cat > "$MANIFEST" <<'EOF'
 # Workspaces Manifest
 
-Reconstruction recipe for the per-task worktrees under `worktrees/`. Each row is enough
-to rebuild a `worktrees/<TASK>/` mini-workspace on a fresh clone: re-create the workspace
+Reconstruction recipe for the per-task worktrees under `workspaces/`. Each row is enough
+to rebuild a `workspaces/<TASK>/` mini-workspace on a fresh clone: re-create the workspace
 worktree, then a worktree of each listed repo on the task's feature branch (which
 `/workspace-sync` has pushed to the submodule remotes). The checkouts themselves are
 gitignored; this file is tracked. Managed by `/workspace` and `/teardown` (`bin/workspace`).
@@ -187,7 +187,7 @@ cmd_create() {
   [ -n "$branch" ] || die "create requires --branch (e.g. feature/dotfiles-zsh)"
   [ -n "$repos" ]  || die "create requires --repos (comma-separated; e.g. dotfiles,tao-te-ching)"
 
-  local ws_dir="$HUB/worktrees/$task"
+  local ws_dir="$HUB/workspaces/$task"
   local -a repo_arr
   IFS=',' read -ra repo_arr <<< "$repos"
   local repo
@@ -199,7 +199,7 @@ cmd_create() {
   if worktree_present "$ws_dir"; then
     info "workspace already at $ws_dir"
   else
-    info "creating workspace at worktrees/$task (detached)"
+    info "creating workspace at workspaces/$task (detached)"
     git -C "$HUB" worktree add --detach "$ws_dir" HEAD >/dev/null
   fi
 
@@ -208,7 +208,7 @@ cmd_create() {
     local repo_path target ib
     repo_path="$(submodule_path "$HUB" "$repo")"
     target="$(submodule_path "$ws_dir" "$repo")"
-    mkdir -p "$(dirname "$target")"   # ensure worktrees/<TASK>/modules/ exists
+    mkdir -p "$(dirname "$target")"   # ensure workspaces/<TASK>/modules/ exists
     ib="$(integration_branch "$repo")"
     git -C "$repo_path" fetch origin "$ib" --quiet 2>/dev/null || warn "$repo: fetch origin/$ib failed (offline?) — proceeding with local refs"
     if worktree_present "$target"; then
@@ -246,7 +246,7 @@ cmd_create() {
 
   # 4. record in the reconstruction manifest (caller commits it)
   manifest_upsert "$task" "$title" "$repos" "$branch"
-  info "manifest: recorded $task (caller should commit worktrees/WORKSPACES.md)"
+  info "manifest: recorded $task (caller should commit workspaces/WORKSPACES.md)"
 
   emit "workspace_dir=$ws_dir task=$task repos=$repos branch=$branch status=ready"
 }
@@ -261,7 +261,7 @@ cmd_sync() {
     esac
   done
   [ -n "$task" ] || die "sync requires --task"
-  local ws_dir="$HUB/worktrees/$task"
+  local ws_dir="$HUB/workspaces/$task"
   worktree_present "$ws_dir" || die "no workspace at $ws_dir (run /workspace $task first)"
 
   local repo any=0 conflicts=0
@@ -276,7 +276,7 @@ cmd_sync() {
     # Detached HEAD → empty $cur; the no-upstream push below would become the invalid
     # `git push -u origin ""`. Bail early with a clear diagnostic instead.
     if [ -z "$cur" ]; then
-      emit "ERROR $repo: detached HEAD in worktrees/$task/$repo — checkout the feature branch before syncing"; conflicts=1; continue
+      emit "ERROR $repo: detached HEAD in workspaces/$task/$repo — checkout the feature branch before syncing"; conflicts=1; continue
     fi
     git -C "$rd" fetch origin "$ib" --quiet 2>/dev/null || { emit "ERROR $repo: fetch origin/$ib failed"; conflicts=1; continue; }
     if git -C "$rd" merge --no-edit "origin/$ib" >/dev/null 2>&1; then
@@ -284,15 +284,15 @@ cmd_sync() {
         if git -C "$rd" push >/dev/null 2>&1; then
           emit "OK $repo: merged origin/$ib into $cur, pushed"
         else
-          emit "ERROR $repo: merged origin/$ib but push failed (resolve in worktrees/$task/$repo)"; conflicts=1
+          emit "ERROR $repo: merged origin/$ib but push failed (resolve in workspaces/$task/$repo)"; conflicts=1
         fi
       elif git -C "$rd" push -u origin "$cur" >/dev/null 2>&1; then
         emit "OK $repo: merged origin/$ib into $cur, pushed (set upstream)"
       else
-        emit "ERROR $repo: merged origin/$ib but initial push failed (resolve in worktrees/$task/$repo)"; conflicts=1
+        emit "ERROR $repo: merged origin/$ib but initial push failed (resolve in workspaces/$task/$repo)"; conflicts=1
       fi
     else
-      emit "CONFLICT $repo: merge of origin/$ib into $cur conflicts — resolve in worktrees/$task/$repo, then re-run sync"
+      emit "CONFLICT $repo: merge of origin/$ib into $cur conflicts — resolve in workspaces/$task/$repo, then re-run sync"
       conflicts=1
     fi
   done
@@ -351,7 +351,7 @@ cmd_teardown() {
     esac
   done
   [ -n "$task" ] || die "teardown requires --task"
-  local ws_dir="$HUB/worktrees/$task"
+  local ws_dir="$HUB/workspaces/$task"
 
   # ── --check: dry-run safety report. Surfaces uncommitted + unpushed work per
   # submodule worktree and changes NOTHING. Lets /teardown run the safety check
@@ -419,7 +419,7 @@ cmd_teardown() {
   # persistent canonical memory and is harmless.
 
   manifest_remove "$task"
-  info "manifest: dropped $task (caller should commit worktrees/WORKSPACES.md)"
+  info "manifest: dropped $task (caller should commit workspaces/WORKSPACES.md)"
   emit "torn_down=$task status=removed"
 }
 

--- a/scripts/workspace
+++ b/scripts/workspace
@@ -14,33 +14,35 @@
 # It is idempotent and never steals focus. All progress/warnings go to stderr;
 # capturable results go to stdout as `key=value` (create) or per-repo result lines.
 #
+# The set of submodules is discovered from the root's .gitmodules, and the root from the
+# caller's cwd — nothing is workspace-specific, so the same engine drives every workspace.
+#
 # Integration branch resolution (the source of truth):
 #   integration_branch(repo) = the branch currently checked out for that submodule in
-#   the TOP-LEVEL workspace checkout, under modules/ (dotfiles→main, tao-te-ching→main, …).
+#   the TOP-LEVEL workspace checkout, under modules/ (e.g. dotfiles→main).
 #   Nothing is hardcoded. Divergence from origin/HEAD is warned about, not blocked.
 #
-# Usage:
-#   workspace create  --task dotfiles-zsh --branch feature/dotfiles-zsh \
-#                     --repos dotfiles [--title "…"]
-#   workspace sync    --task dotfiles-zsh
-#   workspace update-modules [--repos dotfiles,tao-te-ching]
-#   workspace teardown --task dotfiles-zsh [--check]   (--check = dry-run safety report)
-#   workspace integration-branch dotfiles
+# Usage (--task and --issue are interchangeable):
+#   workspace create  --task <ID> --branch <feature-branch> --repos <a,b> [--title "…"]
+#   workspace sync    --task <ID>
+#   workspace update-modules [--repos <a,b>]
+#   workspace teardown --task <ID> [--check]   (--check = dry-run safety report)
+#   workspace integration-branch <repo>
 #   workspace list
 
 set -euo pipefail
 
 # ── locate the TRUE workspace root (the main worktree) ────────────────────────
-# This engine lives on PATH (~/.scripts → modules/dotfiles/scripts/), NOT inside the
-# workspace repo, so it can't self-anchor from its own location. Resolve from the caller's
-# cwd instead:
+# This engine lives on PATH (~/.scripts → modules/dotfiles/scripts/) and is shared across
+# every per-task workspace, NOT inside any one repo — so it can't self-anchor from its own
+# location, and nothing about the root is hardcoded. Resolve from the caller's cwd instead:
 #   1. honor an explicit $WORKSPACE_ROOT (export to override; handy for tests);
 #   2. else climb out of any submodule to the top superproject, then take the parent of
 #      that repo's git COMMON dir. From a linked worktree this still lands on the main
 #      checkout (worktrees share the main .git); climbing first sidesteps the .git/modules
-#      trap that a bare --git-common-dir hits inside a submodule;
-#   3. else fall back to the canonical default path.
-DEFAULT_WORKSPACE_ROOT="$HOME/Development/personal/workspace"
+#      trap that a bare --git-common-dir hits inside a submodule.
+# If neither yields a root (run from outside any checkout), die with a clear message rather
+# than guessing a workspace-specific default.
 resolve_workspace_root() {
   local base sp common
   base="$PWD"
@@ -50,16 +52,28 @@ resolve_workspace_root() {
   if common="$(git -C "$base" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)"; then
     dirname "$common"; return 0
   fi
-  printf '%s' "$DEFAULT_WORKSPACE_ROOT"
+  return 0   # print nothing → caller dies with a clear message
 }
 WORKSPACE_ROOT="${WORKSPACE_ROOT:-$(resolve_workspace_root)}"
+[ -n "$WORKSPACE_ROOT" ] || { printf 'workspace: error: cannot resolve the workspace root from %s — cd into a workspace checkout or export $WORKSPACE_ROOT\n' "$PWD" >&2; exit 1; }
 
-KNOWN_SUBMODULES="dotfiles tao-te-ching zero-based-budget"
-# Submodules are grouped under this dir, both in the main checkout and inside each
-# per-task worktree. Repo identifiers (in --repos and the manifest) stay bare names;
-# this prefix locates them on disk. To flatten back to the root, set MODULES_DIR="".
+# Submodules are grouped under this dir, both in the main checkout and inside each per-task
+# worktree. Repo identifiers (in --repos and the manifest) stay bare names; this prefix
+# locates them on disk. To flatten back to the root, set MODULES_DIR="".
 MODULES_DIR="modules"
 MANIFEST="$WORKSPACE_ROOT/worktrees/WORKSPACES.md"
+
+# Known submodules are DISCOVERED from the root's .gitmodules (repo id = path basename),
+# so the engine adapts to whatever workspace it runs in, with zero hardcoding.
+# Override with $WORKSPACE_SUBMODULES (space-separated) if ever needed.
+discover_submodules() {
+  local gm="$WORKSPACE_ROOT/.gitmodules" p
+  [ -f "$gm" ] || return 0
+  git config -f "$gm" --get-regexp '^submodule\..*\.path$' 2>/dev/null \
+    | awk '{print $2}' | while IFS= read -r p; do [ -n "$p" ] && basename "$p"; done
+}
+KNOWN_SUBMODULES="${WORKSPACE_SUBMODULES:-$(discover_submodules | tr '\n' ' ')}"
+KNOWN_SUBMODULES="${KNOWN_SUBMODULES% }"
 
 # Path to a submodule's checkout, given a base dir (the main root or a worktree dir).
 submodule_path() { if [ -n "$MODULES_DIR" ]; then printf '%s/%s/%s' "$1" "$MODULES_DIR" "$2"; else printf '%s/%s' "$1" "$2"; fi; }
@@ -157,7 +171,7 @@ cmd_create() {
   local task="" branch="" repos="" title=""
   while [ $# -gt 0 ]; do
     case "$1" in
-      --task)   task="$2";   shift 2;;
+      --task|--issue) task="$2"; shift 2;;   # --issue: alias for cross-workspace compatibility
       --branch) branch="$2"; shift 2;;
       --repos)  repos="$2";  shift 2;;
       --title)  title="$2";  shift 2;;
@@ -237,7 +251,7 @@ cmd_sync() {
   local task=""
   while [ $# -gt 0 ]; do
     case "$1" in
-      --task) task="$2"; shift 2;;
+      --task|--issue) task="$2"; shift 2;;
       *) die "sync: unknown flag $1";;
     esac
   done
@@ -326,7 +340,7 @@ cmd_teardown() {
   local task="" check=0
   while [ $# -gt 0 ]; do
     case "$1" in
-      --task)  task="$2"; shift 2;;
+      --task|--issue) task="$2"; shift 2;;
       --check) check=1; shift;;
       *) die "teardown: unknown flag $1";;
     esac

--- a/scripts/workspace
+++ b/scripts/workspace
@@ -195,11 +195,11 @@ cmd_create() {
     is_known_submodule "$repo" || die "create: '$repo' is not a known submodule ($KNOWN_SUBMODULES)"
   done
 
-  # 1. hub-repo worktree (detached @ current hub HEAD — scaffolding only, no pins)
+  # 1. the workspace's top-level worktree (of the hub repo, detached @ current hub HEAD — scaffolding only, no pins)
   if worktree_present "$ws_dir"; then
-    info "hub-repo worktree already at $ws_dir"
+    info "workspace already at $ws_dir"
   else
-    info "creating hub-repo worktree at worktrees/$task (detached)"
+    info "creating workspace at worktrees/$task (detached)"
     git -C "$HUB" worktree add --detach "$ws_dir" HEAD >/dev/null
   fi
 
@@ -406,7 +406,7 @@ cmd_teardown() {
     fi
   done
   if worktree_present "$ws_dir"; then
-    info "removing hub-repo worktree"
+    info "removing workspace"
     git -C "$HUB" worktree remove --force "$ws_dir" || warn "workspace: worktree remove failed for $ws_dir"
   fi
   # prune dangling worktree admin entries
@@ -431,7 +431,7 @@ cmd_list() {
     emit "(no manifest yet)"
   fi
   emit ""
-  emit "Hub worktrees:"
+  emit "Workspace worktrees:"
   git -C "$HUB" worktree list
 }
 

--- a/scripts/workspace
+++ b/scripts/workspace
@@ -1,16 +1,17 @@
 #!/usr/bin/env bash
-# workspace — git/fs engine for per-task, fully-isolated "mini-workspace" worktrees.
+# workspace — git/fs engine for per-task, fully-isolated workspaces.
 #
 # Terms: the HUB is the top-level checkout (the stable integration view containing modules/
-# and worktrees/); a WORKSPACE is a per-task worktree of the hub. The hub repo is the git
-# repo the hub is a checkout of.
+# and worktrees/); a WORKSPACE is the per-task, isolated environment for one issue/PR, and
+# WORKTREE is the git mechanism it's built from. The hub repo is the git repo the hub is a
+# checkout of.
 #
-# A per-task workspace is a worktree of THIS hub repo (carrying CLAUDE.md,
+# A per-task workspace is materialized as a git worktree of THIS hub repo (carrying CLAUDE.md,
 # .claude/, bin/, .cmux/, docs/, …) at  worktrees/<TASK>/ , with a git worktree of each
 # in-scope submodule nested inside it at  worktrees/<TASK>/modules/<repo>  on the task's
-# feature branch (mirroring the main checkout, where submodules live under modules/).
-# Submodule object stores are shared (no re-clone). The top-level repo's view stays a
-# clean, stable integration vantage point; feature work lives entirely in worktrees.
+# feature branch (mirroring the hub, where submodules live under modules/). Submodule object
+# stores are shared (no re-clone). The hub's view stays a clean, stable integration vantage
+# point; feature work lives entirely in worktrees.
 #
 # This script is the deterministic plumbing. It does NOT:
 #   - commit the hub repo        (the slash commands do that: manifest rows, pins)
@@ -194,11 +195,11 @@ cmd_create() {
     is_known_submodule "$repo" || die "create: '$repo' is not a known submodule ($KNOWN_SUBMODULES)"
   done
 
-  # 1. workspace-repo worktree (detached @ current workspace HEAD — scaffolding only, no pins)
+  # 1. hub-repo worktree (detached @ current hub HEAD — scaffolding only, no pins)
   if worktree_present "$ws_dir"; then
-    info "workspace worktree already at $ws_dir"
+    info "hub-repo worktree already at $ws_dir"
   else
-    info "creating workspace worktree at worktrees/$task (detached)"
+    info "creating hub-repo worktree at worktrees/$task (detached)"
     git -C "$HUB" worktree add --detach "$ws_dir" HEAD >/dev/null
   fi
 
@@ -405,7 +406,7 @@ cmd_teardown() {
     fi
   done
   if worktree_present "$ws_dir"; then
-    info "removing workspace worktree"
+    info "removing hub-repo worktree"
     git -C "$HUB" worktree remove --force "$ws_dir" || warn "workspace: worktree remove failed for $ws_dir"
   fi
   # prune dangling worktree admin entries
@@ -430,7 +431,7 @@ cmd_list() {
     emit "(no manifest yet)"
   fi
   emit ""
-  emit "Workspace worktrees:"
+  emit "Hub worktrees:"
   git -C "$HUB" worktree list
 }
 

--- a/zprofile
+++ b/zprofile
@@ -2,7 +2,7 @@ BREW_ENV="$HOME/.cache/brew_env.zsh"
 if [ -r "$BREW_ENV" ]; then
   source "$BREW_ENV"
 else
-  "$HOME/Development/personal/workspace/modules/dotfiles/scripts/generate-brew-env.sh"
+  "$HOME/Development/personal/hub/modules/dotfiles/scripts/generate-brew-env.sh"
   source "$BREW_ENV"
 fi
 


### PR DESCRIPTION
Move the per-task worktree tooling and the shared workflow assets into dotfiles, so the whole workflow lives on PATH / under `~/.claude` (via rcup) and is reusable from any workspace, instead of being repo-local.

## What's added

### Engine + spawner (on PATH via `~/.scripts`)
- **`scripts/workspace`** — the per-task worktree engine (`create` / `sync` / `update-modules` / `teardown` / `integration-branch` / `root` / `list`). It resolves the workspace root from the caller's cwd (climbs out of any submodule → git common dir → main root), honoring a `$WORKSPACE_ROOT` override, and discovers submodules + integration branches from `.gitmodules` and the main checkout at runtime — so one engine drives every workspace with zero per-repo config. Accepts `--issue` as an alias for `--task`.
- **`scripts/cmux-spawn-work`** — spawn a cmux workspace (Claude Code + terminal splits); idempotent, never steals focus.

### Shared Claude assets (symlinked into `~/.claude` via rcup)
- **`claude/commands/{workspace,workspace-sync,update-modules,teardown}.md`** — the four slash commands, now hosted **globally** so every workspace resolves one copy instead of carrying duplicates. Merged supersets: target a tracker issue **or** a PR/MR, generic forge (`gh`/`glab`), no-`cd` self-anchoring, and the "offer to close" teardown.
- **`claude/WORKSPACE.md`** — the host-neutral workflow guide (worktree model, integration-branch invariant, the four-commands table, engine, manifest, memory, cmux conventions, Mermaid style). Each workspace's `CLAUDE.md`/`AGENTS.md` imports it via `@~/.claude/WORKSPACE.md` and layers on its own repo-specific bits.

All shared assets are workspace-agnostic: vocabulary is **workspace / issue / PR-MR**, and any forge/tracker/repo specifics are referenced generically (no hardcoded repos or org names). rcm maps `claude/` → `~/.claude/` non-destructively (leaf symlinks only; existing `~/.claude` contents are untouched).

The companion workspace-repo PR drops its local command copies and slims its `CLAUDE.md` to import the shared guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
