### PR TITLE
meeting-guard: self-heal the in-cmux watcher (cmux restore + in-session respawn)

### DIFF
--- a/config/cmux/cmux.json
+++ b/config/cmux/cmux.json
@@ -2,6 +2,46 @@
   "$schema": "https://raw.githubusercontent.com/manaflow-ai/cmux/main/web/data/cmux.schema.json",
   "schemaVersion": 1,
 
+  // meeting-guard's in-cmux takeover watcher, as a *restorable* workspace.
+  // The single terminal surface runs `meeting-guard watch` as a layout surface
+  // command (not typed-in), so cmux can re-run it on session restore once you
+  // approve its resume prompt (approve `meeting-guard watch` with policy "auto").
+  // scripts/meeting-guard also (re)creates this same workspace in-session
+  // (shell-startup + throttled precmd) to cover a watcher that dies mid-session.
+  // Trigger from the Command Palette (Cmd+Shift+P) as "Meeting Guard".
+  "actions": {
+    "meeting-guard": {
+      "type": "workspaceCommand",
+      "title": "Meeting Guard",
+      "subtitle": "Open the in-cmux meeting takeover watcher",
+      "commandName": "Meeting Guard",
+      "icon": { "type": "symbol", "name": "alarm" },
+      "palette": true
+    }
+  },
+
+  "commands": [
+    {
+      "name": "Meeting Guard",
+      "description": "In-cmux meeting takeover watcher (meeting-guard watch)",
+      "workspace": {
+        "name": "meeting-guard",
+        "color": "#c62828",
+        "layout": {
+          "pane": {
+            "surfaces": [
+              {
+                "type": "terminal",
+                "name": "meeting-guard",
+                "command": "/Users/alexanderjeurissen/Development/personal/hub/modules/dotfiles/scripts/meeting-guard watch"
+              }
+            ]
+          }
+        }
+      }
+    }
+  ],
+
   // Ported from wezterm.lua: Ctrl-T as the tmux-style leader key.
   // Two-step chord syntax: ["leader", "key"] — first stroke is the prefix,
   // second stroke is the action key. See:

--- a/scripts/meeting-guard
+++ b/scripts/meeting-guard
@@ -735,11 +735,12 @@ def cmd_watch(cfg):
 
 
 def _watch_workspace_refs():
-    """Refs of any workspace named WATCH_LABEL (cmux doesn't persist the watch
-    command, so after a restart these are stale idle shells)."""
+    """Refs of any workspace named WATCH_LABEL, or None when cmux couldn't be
+    reached — so callers can tell 'no such workspace' apart from a transient
+    broken-pipe list (the latter must NOT trigger a close/recreate)."""
     r = cmux("list-workspaces")
-    if r is None:
-        return []
+    if r is None or r.returncode != 0:
+        return None
     refs = []
     for line in r.stdout.splitlines():
         if WATCH_LABEL in line:
@@ -749,13 +750,25 @@ def _watch_workspace_refs():
     return refs
 
 
-def spawn_watcher():
-    """Ensure the watch loop is running inside cmux (call from within the session).
+def _watch_cmd():
+    """The watch-loop command as one shell-quoted string. Used identically for
+    `respawn-pane` (start the loop) and `surface resume set` (mark the surface
+    restorable), so cmux's resume approval matches however the surface was made."""
+    return f"{shquote(SELF)} watch"
 
-    cmux doesn't persist a workspace's launch command, so after a restart the
-    `meeting-guard` workspace returns as an idle shell. If one exists (e.g. the
-    user pinned it), revive the command *in place* via `cmux send` — no
-    duplicate, and the pin keeps working. Otherwise spawn a fresh workspace.
+
+def spawn_watcher():
+    """(Re)start the watch loop inside cmux (call from within the session).
+
+    Restart the loop *in place* with `respawn-pane`: this preserves a pinned
+    meeting-guard workspace and its position and never leaves a duplicate (a
+    close+recreate can't even touch a pinned workspace). The surface is also
+    tagged with a restorable resume command (`surface resume set`) so a cmux/host
+    restart re-runs the watcher once you approve it in the UI
+    (terminal.resumeCommands, policy `auto`). This is likewise the mid-session
+    self-heal path: the shell-startup hook and the throttled precmd hook (see
+    zshrc) both funnel here when the heartbeat goes stale. Idempotent: a no-op
+    while it's heartbeating.
     """
     if watcher_alive():
         return "already running"
@@ -768,17 +781,31 @@ def spawn_watcher():
             return "spawn in progress elsewhere"
         os.utime(lock, None)  # stale lock — take it over
     try:
-        inner = f"{shquote(SELF)} watch"
         refs = _watch_workspace_refs()
+        if refs is None:
+            return "cmux unreachable (will retry)"  # transient; hook retries later
+        cmd = _watch_cmd()
         if refs:
-            cmux("send", "--workspace", refs[0], inner + "\n")
-            time.sleep(1.5)
-            return f"revived in {refs[0]}" + (" + heartbeating" if watcher_alive() else " (verify)")
-        res = cmux("new-workspace", "--name", WATCH_LABEL, "--command", inner, "--focus", "false")
-        if res is None or res.returncode != 0:
-            return "FAILED (not in a cmux session? run this from a cmux terminal)"
-        time.sleep(1)
-        return "spawned" + (" + heartbeating" if watcher_alive() else "")
+            ref = refs[0]  # reuse the existing (possibly pinned) workspace
+        else:
+            res = cmux("new-workspace", "--name", WATCH_LABEL, "--focus", "false")
+            if res is None or res.returncode != 0:
+                return "FAILED (not in a cmux session? run this from a cmux terminal)"
+            mo = re.search(r"workspace:\d+", res.stdout or "")
+            if not mo:
+                return "FAILED (could not resolve new workspace ref)"
+            ref = mo.group(0)
+            time.sleep(1)  # let the fresh shell finish coming up before respawn
+        # start the loop in place, then mark the surface restorable across restart
+        cmux("respawn-pane", "--workspace", ref, "--command", cmd)
+        cmux("surface", "resume", "set", "--workspace", ref,
+             "--kind", "tmux", "--name", WATCH_LABEL, "--shell", cmd)
+        for _ in range(6):  # let the loop's first heartbeat land
+            time.sleep(0.5)
+            if watcher_alive():
+                break
+        verb = "respawned" if refs else "spawned"
+        return f"{verb} in {ref}" + (" + heartbeating" if watcher_alive() else " (verify)")
     finally:
         try:
             os.remove(lock)

--- a/zshrc
+++ b/zshrc
@@ -98,12 +98,27 @@ if [[ -f .venv/bin/activate ]]; then
   source .venv/bin/activate
 fi
 
-# meeting-guard self-heal: revive the in-cmux meeting takeover watcher after a
-# cmux/host restart. No-op outside cmux or where the binary is absent, so it's
-# safe to carry across machines. Shipped as scripts/meeting-guard (deployed to
-# ~/.scripts, on PATH).
+# meeting-guard self-heal: keep the in-cmux takeover watcher alive. It renders
+# the red meeting takeover from inside cmux and dies two ways — a cmux/host
+# restart (cmux restores its workspace but only re-runs the surface command once
+# you approve its resume prompt) or the loop itself exiting mid-session. launchd
+# can't drive cmux from outside its session, so revival must happen in-session:
+# run ensure-watch at shell startup AND from a throttled precmd (per-shell, at
+# most once/2min) so a watcher that dies mid-session is revived without waiting
+# for a brand-new shell. No-op outside cmux or where the binary is absent, so
+# it's safe to carry across machines. Shipped as scripts/meeting-guard (~/.scripts).
 if [[ -n "$CMUX_WORKSPACE_ID" ]] && command -v meeting-guard >/dev/null 2>&1; then
-  ( meeting-guard ensure-watch >/dev/null 2>&1 & )
+  autoload -Uz add-zsh-hook
+  zmodload zsh/datetime 2>/dev/null
+  typeset -g _mg_last_heal=0
+  _meeting_guard_heal() {
+    local now=${EPOCHSECONDS:-0}
+    (( now && now - _mg_last_heal < 120 )) && return   # throttle; skip if unset
+    _mg_last_heal=$now
+    ( meeting-guard ensure-watch >/dev/null 2>&1 & )
+  }
+  add-zsh-hook precmd _meeting_guard_heal
+  _meeting_guard_heal   # run once now (covers this fresh shell)
 fi
 
 # vim: foldmethod=marker:sw=2:foldlevel=10


### PR DESCRIPTION
## What

Self-heal the meeting-guard takeover watcher so it survives the two ways it dies — a cmux/host restart (cmux restores the workspace but comes back an idle shell, not re-running the typed launch command) and the loop exiting mid-session. Until now a watcher that died with no new shell opened stayed dead (observed: 9 days), silently degrading every takeover to the macOS modal fallback.

## How

launchd can't drive cmux from outside its session (a launchd `cmux` call gets EPIPE where the same call works in-session), so revival happens **in-session**:

- **`spawn_watcher`** restarts the loop *in place* with `respawn-pane` instead of typing into a fresh shell, and tags the surface with a restorable resume command (`surface resume set`). In-place respawn preserves a pinned meeting-guard workspace + position and never leaves a duplicate.
- **`_watch_workspace_refs`** distinguishes "cmux unreachable" (`None`) from "no such workspace" (`[]`) so a transient EPIPE can't trigger a bogus spawn.
- **`zshrc`** runs `ensure-watch` at shell startup **and** from a throttled `precmd` (per-shell, ≤once/2min) so a mid-session death is revived without waiting for a brand-new shell.
- **`cmux.json`** defines a "Meeting Guard" palette workspace whose surface runs the watcher, restorable on session restore.

## Note

Restart recovery still needs a one-time UI approval of the `meeting-guard watch` resume command (`terminal.resumeCommands`, policy auto); the precmd backstop covers it meanwhile and covers mid-session death outright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
