### PR TITLE
claude: graduate cmux-* + plannotator skills + read-only-traversal hook to dotfiles

### DIFF
--- a/claude/WORKSPACE.md
+++ b/claude/WORKSPACE.md
@@ -97,6 +97,20 @@ slash commands orchestrate the tracker, scope confirmation, the hub-repo commits
 pins), and cmux spawning. The commands are global (`~/.claude/commands/`, symlinked from
 `dotfiles/claude/commands/`), so every hub shares one copy.
 
+### Shared Claude assets (host-neutral, dotfiles-managed)
+
+Alongside the commands, dotfiles carries two more host-neutral layers, linked into `~/.claude/` by
+`rcup` and therefore shared by every hub + every project:
+
+- **`dotfiles/claude/skills/` → `~/.claude/skills/`** — global skills. The `cmux-*` family lives here
+  (cmux is host-neutral), so hubs must **not** keep hub-local copies under `<hub>/.claude/skills/`.
+- **`dotfiles/claude/hooks/` → `~/.claude/hooks/`** — global hooks. `allow-readonly-traversal.py` is
+  wired as a `PreToolUse(Bash)` hook in `~/.claude/settings.json`; it auto-approves provably
+  read-only `cd`+`/dev/null` submodule traversals (and only those — it abstains otherwise, keyed to
+  `CLAUDE_PROJECT_DIR`), removing the built-in cd+redirect approval prompt.
+
+To add either, drop the file under `dotfiles/claude/{skills,hooks}/` and run `rcup`.
+
 ### The manifest — `workspaces/WORKSPACES.md`
 
 Tracked, while the per-issue checkouts are gitignored (`workspaces/*/`). One row per active workspace

--- a/claude/hooks/allow-readonly-traversal.py
+++ b/claude/hooks/allow-readonly-traversal.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""PreToolUse(Bash) hook: auto-approve read-only submodule traversals.
+
+Why this exists
+---------------
+Claude Code has a built-in safety check that forces manual approval for any
+single Bash command that BOTH `cd`s AND redirects output (e.g.
+`cd core 2>/dev/null && find . ...`). The reasoning is sound in general: once
+`cd` runs, a redirect target resolves against a different working directory, so
+permission allow-rules can't be matched safely ("path resolution bypass"). That
+check is intentionally not allowlistable.
+
+In a submodule hub, though, the common shape is harmless: hop into a submodule
+under modules/ (or a per-issue workspace) and run read-only commands while
+suppressing stderr to /dev/null. This hook recognizes exactly that shape and
+returns `permissionDecision: "allow"`, which short-circuits the built-in prompt.
+
+Host-neutral: lives in dotfiles (claude/hooks/), symlinked into ~/.claude/hooks/
+and wired globally in ~/.claude/settings.json, so every project benefits. The
+cd-target check keys off CLAUDE_PROJECT_DIR, so it stays scoped per-project.
+
+Safety model
+------------
+The bypass the built-in guards against is "a redirect writes somewhere
+unexpected after a cd". We only auto-allow when there are NO writes at all:
+
+  * the ONLY redirections present are to /dev/null (or 2>&1) — any redirect to a
+    real file, append (>>), here-doc, or process/command substitution -> abstain
+  * no command substitution `$(...)` / backticks, no `${...}`/`$` expansion,
+    no backgrounding `&`, no subshell grouping `( ... )`, no newlines
+  * every pipeline stage's executable is in a curated read-only allowlist
+  * `find` may not use -exec/-execdir/-ok/-okdir/-delete/-fprint*/-fls
+  * `git` must use a read-only subcommand (log/show/diff/status/...); mutating
+    forms like branch -D, tag -d, config <write>, checkout, reset are excluded
+  * `sort` may not use -o/--output
+  * `cd` targets are restricted to the workspace tree (relative paths, or
+    absolute paths under the project root)
+
+When ANY condition is not met, the hook stays silent (exit 0, no output) and the
+normal permission flow runs — including the user's deny rules (git push, rm -rf,
+sudo). A false "abstain" just means the usual prompt appears; we never relax a
+deny. Auto-approval only ever widens to provably read-only traversal.
+"""
+
+import json
+import os
+import re
+import shlex
+import sys
+from typing import NoReturn
+
+
+def abstain() -> NoReturn:
+    """Emit nothing and let the normal permission flow handle the call."""
+    sys.exit(0)
+
+
+# Executables that cannot mutate the filesystem in their bare/common forms.
+READ_VERBS = {
+    "cd", "ls", "cat", "head", "tail", "wc", "echo", "printf",
+    "grep", "rg", "find", "pwd", "true", "basename", "dirname",
+    "realpath", "stat", "file", "nl", "sort", "uniq", "cut", "tr",
+    "comm", "column", "rev", "fold", "tac", "cksum",
+}
+
+# git subcommands that are read-only in EVERY form (no args can mutate).
+GIT_READ = {
+    "log", "show", "diff", "status", "ls-tree", "ls-files", "rev-parse",
+    "rev-list", "describe", "blame", "cat-file", "shortlog", "for-each-ref",
+    "name-rev", "grep", "whatchanged", "show-ref", "merge-base", "var",
+}
+
+# git global options that take a value (skip the option AND its argument).
+GIT_OPTS_WITH_ARG = {"-C", "-c", "--git-dir", "--work-tree", "--namespace", "--exec-path"}
+
+# find primaries that execute or write — disqualify the whole command.
+FIND_DANGEROUS = {
+    "-exec", "-execdir", "-ok", "-okdir", "-delete",
+    "-fprint", "-fprintf", "-fprintf0", "-fls",
+}
+
+
+def project_root() -> str:
+    root = os.environ.get("CLAUDE_PROJECT_DIR")
+    if root:
+        return os.path.realpath(root)
+    # CLAUDE_PROJECT_DIR is always set in hook context; this is just a safety net.
+    # (The hook is installed globally at ~/.claude/hooks/, so it can't derive the
+    # project root from its own path — fall back to the current working directory.)
+    return os.path.realpath(os.getcwd())
+
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        abstain()
+
+    if data.get("tool_name") != "Bash":
+        abstain()
+
+    cmd = ((data.get("tool_input") or {}).get("command") or "").strip()
+    if not cmd:
+        abstain()
+
+    # --- Hard rejects: constructs that hide execution or escape our analysis ---
+    for bad in ("$(", "`", "<(", ">(", "${", "$", "\n", "\r"):
+        if bad in cmd:
+            abstain()
+
+    # --- Redirection check: strip allowed /dev/null + fd-dup redirects, then
+    #     any leftover < or > means a redirect to something we won't vouch for. ---
+    stripped = re.sub(r"(?:\d*|&)>>?\s*/dev/null", " ", cmd)
+    stripped = re.sub(r"\d*>&\d+", " ", stripped)
+    if "<" in stripped or ">" in stripped:
+        abstain()
+
+    # --- Backgrounding / subshell grouping ---
+    no_and = stripped.replace("&&", " ").replace("||", " ")
+    if "&" in no_and:          # a lone & = background job
+        abstain()
+    if "(" in stripped or ")" in stripped:
+        abstain()
+
+    # --- Tokenize, honoring quotes, with shell operators as their own tokens ---
+    try:
+        lex = shlex.shlex(stripped, posix=True, punctuation_chars=True)
+        lex.whitespace_split = True
+        tokens = list(lex)
+    except ValueError:
+        abstain()  # unbalanced quotes, etc.
+
+    OPERATORS = {"&&", "||", "|", ";"}
+    segments, seg = [], []
+    for tok in tokens:
+        if tok in OPERATORS:
+            if seg:
+                segments.append(seg)
+                seg = []
+        else:
+            seg.append(tok)
+    if seg:
+        segments.append(seg)
+
+    if not segments:
+        abstain()
+
+    root = project_root()
+
+    for seg in segments:
+        exe = seg[0]
+
+        if exe == "git":
+            sub, i = None, 1
+            while i < len(seg):
+                tok = seg[i]
+                if tok in GIT_OPTS_WITH_ARG:
+                    i += 2
+                    continue
+                if tok.startswith("-"):
+                    i += 1
+                    continue
+                sub = tok
+                break
+            if sub not in GIT_READ:
+                abstain()
+            continue
+
+        if exe not in READ_VERBS:
+            abstain()
+
+        if exe == "find" and any(t in FIND_DANGEROUS for t in seg[1:]):
+            abstain()
+
+        if exe == "sort" and any(
+            t in ("-o", "--output") or t.startswith("--output=") for t in seg[1:]
+        ):
+            abstain()
+
+        if exe == "cd":
+            target = next((t for t in seg[1:] if not t.startswith("-")), None)
+            if target and target.startswith("/"):
+                rp = os.path.realpath(target)
+                if not (rp == root or rp.startswith(root + os.sep)):
+                    abstain()
+
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow",
+            "permissionDecisionReason": (
+                "Read-only submodule traversal (cd + read verbs, redirects only "
+                "to /dev/null) — auto-approved by allow-readonly-traversal hook."
+            ),
+        }
+    }))
+
+
+if __name__ == "__main__":
+    main()

--- a/claude/skills/cmux-browser/SKILL.md
+++ b/claude/skills/cmux-browser/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: cmux-browser
+description: End-user browser automation with cmux. Use when you need to open sites, interact with pages, wait for state changes, and extract data from cmux browser surfaces.
+---
+
+# Browser Automation with cmux
+
+Use this skill for browser tasks inside cmux webviews.
+
+## Core Workflow
+
+1. Open or target a browser surface.
+2. Verify navigation with `get url` before waiting or snapshotting.
+3. Snapshot (`--interactive`) to get fresh element refs.
+4. Act with refs (`click`, `fill`, `type`, `select`, `press`).
+5. Wait for state changes.
+6. Re-snapshot after DOM/navigation changes.
+
+```bash
+cmux --json browser open https://example.com
+# use returned surface ref, for example: surface:7
+
+cmux browser surface:7 get url
+cmux browser surface:7 wait --load-state complete --timeout-ms 15000
+cmux browser surface:7 snapshot --interactive
+cmux browser surface:7 fill e1 "hello"
+cmux --json browser surface:7 click e2 --snapshot-after
+cmux browser surface:7 snapshot --interactive
+```
+
+## Surface Targeting
+
+```bash
+# identify current context
+cmux identify --json
+
+# open routed to a specific topology target
+cmux browser open https://example.com --workspace workspace:2 --window window:1 --json
+```
+
+Notes:
+- CLI output defaults to short refs (`surface:N`, `pane:N`, `workspace:N`, `window:N`).
+- UUIDs are still accepted on input; only request UUID output when needed (`--id-format uuids|both`).
+- Keep using one `surface:N` per task unless you intentionally switch.
+
+## Wait Support
+
+cmux supports wait patterns similar to agent-browser:
+
+```bash
+cmux browser <surface> wait --selector "#ready" --timeout-ms 10000
+cmux browser <surface> wait --text "Success" --timeout-ms 10000
+cmux browser <surface> wait --url-contains "/dashboard" --timeout-ms 10000
+cmux browser <surface> wait --load-state complete --timeout-ms 15000
+cmux browser <surface> wait --function "document.readyState === 'complete'" --timeout-ms 10000
+```
+
+## Common Flows
+
+### Form Submit
+
+```bash
+cmux --json browser open https://example.com/signup
+cmux browser surface:7 get url
+cmux browser surface:7 wait --load-state complete --timeout-ms 15000
+cmux browser surface:7 snapshot --interactive
+cmux browser surface:7 fill e1 "Jane Doe"
+cmux browser surface:7 fill e2 "jane@example.com"
+cmux --json browser surface:7 click e3 --snapshot-after
+cmux browser surface:7 wait --url-contains "/welcome" --timeout-ms 15000
+cmux browser surface:7 snapshot --interactive
+```
+
+### Clear an Input
+
+```bash
+cmux browser surface:7 fill e11 "" --snapshot-after --json
+cmux browser surface:7 get value e11 --json
+```
+
+### Stable Agent Loop (Recommended)
+
+```bash
+# navigate -> verify -> wait -> snapshot -> action -> snapshot
+cmux browser surface:7 get url
+cmux browser surface:7 wait --load-state complete --timeout-ms 15000
+cmux browser surface:7 snapshot --interactive
+cmux --json browser surface:7 click e5 --snapshot-after
+cmux browser surface:7 snapshot --interactive
+```
+
+If `get url` is empty or `about:blank`, navigate first instead of waiting on load state.
+
+## Deep-Dive References
+
+| Reference | When to Use |
+|-----------|-------------|
+| [references/commands.md](references/commands.md) | Full browser command mapping and quick syntax |
+| [references/snapshot-refs.md](references/snapshot-refs.md) | Ref lifecycle and stale-ref troubleshooting |
+| [references/authentication.md](references/authentication.md) | Login/OAuth/2FA patterns and state save/load |
+| [references/authentication.md#saving-authentication-state](references/authentication.md#saving-authentication-state) | Save authenticated state right after login |
+| [references/session-management.md](references/session-management.md) | Multi-surface isolation and state persistence patterns |
+| [references/video-recording.md](references/video-recording.md) | Current recording status and practical alternatives |
+| [references/proxy-support.md](references/proxy-support.md) | Proxy behavior in WKWebView and workarounds |
+
+## Ready-to-Use Templates
+
+| Template | Description |
+|----------|-------------|
+| [templates/form-automation.sh](templates/form-automation.sh) | Snapshot/ref form fill loop |
+| [templates/authenticated-session.sh](templates/authenticated-session.sh) | Login once, save/load state |
+| [templates/capture-workflow.sh](templates/capture-workflow.sh) | Navigate + capture snapshots/screenshots |
+
+## Limits (WKWebView)
+
+These commands currently return `not_supported` because they rely on Chrome/CDP-only APIs not exposed by WKWebView:
+- viewport emulation
+- offline emulation
+- trace/screencast recording
+- network route interception/mocking
+- low-level raw input injection
+
+Use supported high-level commands (`click`, `fill`, `press`, `scroll`, `wait`, `snapshot`) instead.
+
+## Troubleshooting
+
+### `js_error` on `snapshot --interactive` or `eval`
+
+Some complex pages can reject or break the JavaScript used for rich snapshots and ad-hoc evaluation.
+
+Recovery steps:
+
+```bash
+cmux browser surface:7 get url
+cmux browser surface:7 get text body
+cmux browser surface:7 get html body
+```
+
+- Use `get url` first so you know whether the page actually navigated.
+- Fall back to `get text body` or `get html body` when `snapshot --interactive` or `eval` returns `js_error`.
+- If the page is still failing, navigate to a simpler intermediate page, then retry the task from there.

--- a/claude/skills/cmux-browser/agents/openai.yaml
+++ b/claude/skills/cmux-browser/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cmux Browser"
+  short_description: "Automate cmux webview surfaces with snapshot/ref workflows."
+  default_prompt: "Use this skill for browser automation via cmux CLI: identify target surface, snapshot interactive refs, perform actions, wait for state changes, and re-snapshot to avoid stale refs."

--- a/claude/skills/cmux-browser/references/authentication.md
+++ b/claude/skills/cmux-browser/references/authentication.md
@@ -1,0 +1,122 @@
+# Authentication Patterns
+
+Login flows, session persistence, OAuth, and 2FA patterns for cmux browser surfaces.
+
+**Related**: [session-management.md](session-management.md), [SKILL.md](../SKILL.md)
+
+## Contents
+
+- [Basic Login Flow](#basic-login-flow)
+- [Saving Authentication State](#saving-authentication-state)
+- [Restoring Authentication](#restoring-authentication)
+- [OAuth / SSO Flows](#oauth--sso-flows)
+- [Two-Factor Authentication](#two-factor-authentication)
+- [Cookie-Based Auth](#cookie-based-auth)
+- [Token Refresh Handling](#token-refresh-handling)
+- [Security Best Practices](#security-best-practices)
+
+## Basic Login Flow
+
+```bash
+cmux browser open https://app.example.com/login --json
+cmux browser surface:7 wait --load-state complete --timeout-ms 15000
+
+cmux browser surface:7 snapshot --interactive
+# [ref=e1] email, [ref=e2] password, [ref=e3] submit
+
+cmux browser surface:7 fill e1 "user@example.com"
+cmux browser surface:7 fill e2 "$APP_PASSWORD"
+cmux browser surface:7 click e3 --snapshot-after --json
+cmux browser surface:7 wait --url-contains "/dashboard" --timeout-ms 20000
+```
+
+## Saving Authentication State
+
+After logging in, save state for reuse:
+
+```bash
+cmux browser surface:7 state save ./auth-state.json
+```
+
+State includes cookies, localStorage, sessionStorage, and open tab metadata for that surface.
+
+## Restoring Authentication
+
+```bash
+cmux browser open https://app.example.com --json
+cmux browser surface:8 state load ./auth-state.json
+cmux browser surface:8 goto https://app.example.com/dashboard
+cmux browser surface:8 snapshot --interactive
+```
+
+## OAuth / SSO Flows
+
+```bash
+cmux browser open https://app.example.com/auth/google --json
+cmux browser surface:7 wait --url-contains "accounts.google.com" --timeout-ms 30000
+cmux browser surface:7 snapshot --interactive
+
+cmux browser surface:7 fill e1 "user@gmail.com"
+cmux browser surface:7 click e2 --snapshot-after --json
+
+cmux browser surface:7 wait --url-contains "app.example.com" --timeout-ms 45000
+cmux browser surface:7 state save ./oauth-state.json
+```
+
+## Two-Factor Authentication
+
+```bash
+cmux browser open https://app.example.com/login --json
+cmux browser surface:7 snapshot --interactive
+cmux browser surface:7 fill e1 "user@example.com"
+cmux browser surface:7 fill e2 "$APP_PASSWORD"
+cmux browser surface:7 click e3
+
+# complete 2FA manually in the webview, then:
+cmux browser surface:7 wait --url-contains "/dashboard" --timeout-ms 120000
+cmux browser surface:7 state save ./2fa-state.json
+```
+
+## Cookie-Based Auth
+
+```bash
+cmux browser surface:7 cookies set session_token "abc123xyz"
+cmux browser surface:7 goto https://app.example.com/dashboard
+```
+
+## Token Refresh Handling
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+STATE_FILE="./auth-state.json"
+SURFACE="surface:7"
+
+if [ -f "$STATE_FILE" ]; then
+  cmux browser "$SURFACE" state load "$STATE_FILE"
+fi
+
+cmux browser "$SURFACE" goto https://app.example.com/dashboard
+URL=$(cmux browser "$SURFACE" get url)
+
+if printf '%s' "$URL" | grep -q '/login'; then
+  cmux browser "$SURFACE" snapshot --interactive
+  cmux browser "$SURFACE" fill e1 "$APP_USERNAME"
+  cmux browser "$SURFACE" fill e2 "$APP_PASSWORD"
+  cmux browser "$SURFACE" click e3
+  cmux browser "$SURFACE" wait --url-contains "/dashboard" --timeout-ms 20000
+  cmux browser "$SURFACE" state save "$STATE_FILE"
+fi
+```
+
+## Security Best Practices
+
+1. Never commit state files (they include auth tokens).
+2. Use environment variables for credentials.
+3. Clear state/cookies after sensitive tasks:
+
+```bash
+cmux browser surface:7 cookies clear
+rm -f ./auth-state.json
+```

--- a/claude/skills/cmux-browser/references/commands.md
+++ b/claude/skills/cmux-browser/references/commands.md
@@ -1,0 +1,108 @@
+# Command Reference (cmux Browser)
+
+This maps common `agent-browser` usage to `cmux browser` usage.
+
+## Direct Equivalents
+
+- `agent-browser open <url>` -> `cmux browser open <url>`
+- `agent-browser goto|navigate <url>` -> `cmux browser <surface> goto|navigate <url>`
+- `agent-browser snapshot -i` -> `cmux browser <surface> snapshot --interactive`
+- `agent-browser click <ref>` -> `cmux browser <surface> click <ref>`
+- `agent-browser fill <ref> <text>` -> `cmux browser <surface> fill <ref> <text>`
+- `agent-browser type <ref> <text>` -> `cmux browser <surface> type <ref> <text>`
+- `agent-browser select <ref> <value>` -> `cmux browser <surface> select <ref> <value>`
+- `agent-browser get text <ref>` -> `cmux browser <surface> get text <ref-or-selector>`
+- `agent-browser get url` -> `cmux browser <surface> get url`
+- `agent-browser get title` -> `cmux browser <surface> get title`
+
+## Core Command Groups
+
+### Navigation
+
+```bash
+cmux browser open <url>                        # opens in caller's workspace (uses CMUX_WORKSPACE_ID)
+cmux browser open <url> --workspace <id|ref>   # opens in a specific workspace
+cmux browser <surface> goto <url>
+cmux browser <surface> back|forward|reload
+cmux browser <surface> get url|title
+```
+
+> **Workspace context:** `browser open` targets the workspace of the terminal where the command is run (via `CMUX_WORKSPACE_ID`), even if a different workspace is currently focused. Use `--workspace` to override.
+
+### Snapshot and Inspection
+
+```bash
+cmux browser <surface> snapshot --interactive
+cmux browser <surface> snapshot --interactive --compact --max-depth 3
+cmux browser <surface> get text body
+cmux browser <surface> get html body
+cmux browser <surface> get value "#email"
+cmux browser <surface> get attr "#email" --attr placeholder
+cmux browser <surface> get count ".row"
+cmux browser <surface> get box "#submit"
+cmux browser <surface> get styles "#submit" --property color
+cmux browser <surface> eval '<js>'
+```
+
+### Interaction
+
+```bash
+cmux browser <surface> click|dblclick|hover|focus <selector-or-ref>
+cmux browser <surface> fill <selector-or-ref> [text]   # empty text clears
+cmux browser <surface> type <selector-or-ref> <text>
+cmux browser <surface> press|keydown|keyup <key>
+cmux browser <surface> select <selector-or-ref> <value>
+cmux browser <surface> check|uncheck <selector-or-ref>
+cmux browser <surface> scroll [--selector <css>] [--dx <n>] [--dy <n>]
+```
+
+### Wait
+
+```bash
+cmux browser <surface> wait --selector "#ready" --timeout-ms 10000
+cmux browser <surface> wait --text "Done" --timeout-ms 10000
+cmux browser <surface> wait --url-contains "/dashboard" --timeout-ms 10000
+cmux browser <surface> wait --load-state complete --timeout-ms 15000
+cmux browser <surface> wait --function "document.readyState === 'complete'" --timeout-ms 10000
+```
+
+### Session/State
+
+```bash
+cmux browser <surface> cookies get|set|clear ...
+cmux browser <surface> storage local|session get|set|clear ...
+cmux browser <surface> tab list|new|switch|close ...
+cmux browser <surface> state save|load <path>
+```
+
+### Diagnostics
+
+```bash
+cmux browser <surface> console list|clear
+cmux browser <surface> errors list|clear
+cmux browser <surface> highlight <selector>
+cmux browser <surface> screenshot
+cmux browser <surface> download wait --timeout-ms 10000
+```
+
+## Agent Reliability Tips
+
+- Use `--snapshot-after` on mutating actions to return a fresh post-action snapshot.
+- Re-snapshot after navigation, modal open/close, or major DOM changes.
+- Prefer short handles in outputs by default (`surface:N`, `pane:N`, `workspace:N`, `window:N`).
+- Use `--id-format both` only when a UUID must be logged/exported.
+
+## Known WKWebView Gaps (`not_supported`)
+
+- `browser.viewport.set`
+- `browser.geolocation.set`
+- `browser.offline.set`
+- `browser.trace.start|stop`
+- `browser.network.route|unroute|requests`
+- `browser.screencast.start|stop`
+- `browser.input_mouse|input_keyboard|input_touch`
+
+See also:
+- [snapshot-refs.md](snapshot-refs.md)
+- [authentication.md](authentication.md)
+- [session-management.md](session-management.md)

--- a/claude/skills/cmux-browser/references/proxy-support.md
+++ b/claude/skills/cmux-browser/references/proxy-support.md
@@ -1,0 +1,37 @@
+# Proxy Support
+
+How proxy behavior works for cmux browser automation.
+
+**Related**: [commands.md](commands.md), [SKILL.md](../SKILL.md)
+
+## Contents
+
+- [Current Behavior](#current-behavior)
+- [What Is Not Exposed via CLI](#what-is-not-exposed-via-cli)
+- [Workarounds](#workarounds)
+- [Verification](#verification)
+
+## Current Behavior
+
+cmux browser uses WKWebView networking. Proxy behavior follows macOS/system networking and app process environment.
+
+## What Is Not Exposed via CLI
+
+There is currently no first-class `cmux browser proxy ...` command for per-surface proxy routing.
+
+Why: WKWebView does not provide CDP-style per-context proxy controls equivalent to Chrome automation stacks.
+
+## Workarounds
+
+1. Configure system/network-level proxy for the environment where cmux runs.
+2. Route traffic through an upstream gateway you control.
+3. Validate behavior with explicit IP checks.
+
+## Verification
+
+```bash
+cmux browser open https://httpbin.org/ip --json
+cmux browser surface:7 get text body
+```
+
+Compare returned IP against expected proxy egress.

--- a/claude/skills/cmux-browser/references/session-management.md
+++ b/claude/skills/cmux-browser/references/session-management.md
@@ -1,0 +1,94 @@
+# Session Management
+
+cmux uses isolated browser contexts per surface. Treat each browser surface as its own session.
+
+**Related**: [authentication.md](authentication.md), [SKILL.md](../SKILL.md)
+
+## Contents
+
+- [Surface-Based Sessions](#surface-based-sessions)
+- [Isolation Properties](#isolation-properties)
+- [State Persistence](#state-persistence)
+- [Common Patterns](#common-patterns)
+- [Cleanup](#cleanup)
+- [Best Practices](#best-practices)
+
+## Surface-Based Sessions
+
+```bash
+# session A
+cmux browser open https://app.example.com/login --json
+# -> surface:7
+
+# session B
+cmux browser open https://example.com --json
+# -> surface:8
+
+cmux browser surface:7 get url
+cmux browser surface:8 get url
+```
+
+## Isolation Properties
+
+Each surface has independent:
+- cookies
+- localStorage/sessionStorage
+- tab list and active tab
+- navigation history
+
+## State Persistence
+
+### Save State
+
+```bash
+cmux browser surface:7 state save /tmp/auth-state.json
+```
+
+### Load State
+
+```bash
+cmux browser surface:8 state load /tmp/auth-state.json
+cmux browser surface:8 goto https://app.example.com/dashboard
+```
+
+## Common Patterns
+
+### Reuse Auth Across New Surface
+
+```bash
+cmux browser open https://app.example.com/login --json
+# login on surface:7 ...
+cmux browser surface:7 state save /tmp/auth.json
+
+cmux browser open https://app.example.com --json
+# assume surface:8
+cmux browser surface:8 state load /tmp/auth.json
+cmux browser surface:8 goto https://app.example.com/dashboard
+```
+
+### Parallel Multi-Site Tasks
+
+```bash
+cmux browser open https://site-a.example --json
+cmux browser open https://site-b.example --json
+cmux browser open https://site-c.example --json
+
+cmux browser surface:11 get text body > /tmp/a.txt
+cmux browser surface:12 get text body > /tmp/b.txt
+cmux browser surface:13 get text body > /tmp/c.txt
+```
+
+## Cleanup
+
+```bash
+cmux close-surface --surface surface:7
+cmux close-surface --surface surface:8
+rm -f /tmp/auth-state.json
+```
+
+## Best Practices
+
+1. Name/log surfaces in your script output so actions stay attributable.
+2. Keep one task per surface to avoid ref churn.
+3. Save state after successful auth milestones.
+4. Re-snapshot after switching tabs/pages inside a surface.

--- a/claude/skills/cmux-browser/references/snapshot-refs.md
+++ b/claude/skills/cmux-browser/references/snapshot-refs.md
@@ -1,0 +1,88 @@
+# Snapshot and Refs
+
+Element refs from snapshots make browser automation compact and reliable.
+
+**Related**: [commands.md](commands.md), [SKILL.md](../SKILL.md)
+
+## Contents
+
+- [How Refs Work](#how-refs-work)
+- [The Snapshot Command](#the-snapshot-command)
+- [Using Refs](#using-refs)
+- [Ref Lifecycle](#ref-lifecycle)
+- [Best Practices](#best-practices)
+- [Troubleshooting](#troubleshooting)
+
+## How Refs Work
+
+Classic flow:
+
+```text
+full DOM/HTML -> selector guessing -> action
+```
+
+cmux flow:
+
+```text
+snapshot -> refs (e1/e2/...) -> direct action
+```
+
+## The Snapshot Command
+
+```bash
+cmux browser surface:7 snapshot
+cmux browser surface:7 snapshot --interactive
+cmux browser surface:7 snapshot --interactive --compact --max-depth 3
+```
+
+## Using Refs
+
+```bash
+cmux browser surface:7 click e6
+cmux browser surface:7 fill e10 "user@example.com"
+cmux browser surface:7 fill e11 "password123"
+cmux browser surface:7 click e12
+```
+
+## Ref Lifecycle
+
+Refs are invalidated when page structure changes.
+
+```bash
+cmux browser surface:7 snapshot --interactive
+# e1 is "Next"
+
+cmux browser surface:7 click e1
+
+# page changed, take a fresh snapshot
+cmux browser surface:7 snapshot --interactive
+```
+
+## Best Practices
+
+1. Snapshot before interacting.
+2. Re-snapshot after navigation/modal/open-close flows.
+3. Use `--snapshot-after` on mutating actions.
+4. Scope snapshots with `--selector` for very large pages.
+
+## Troubleshooting
+
+### not_found / stale ref
+
+```bash
+cmux browser surface:7 snapshot --interactive
+```
+
+### Element missing due visibility/timing
+
+```bash
+cmux browser surface:7 wait --selector "#target" --timeout-ms 10000
+cmux browser surface:7 scroll --dy 400
+cmux browser surface:7 snapshot --interactive
+```
+
+### Too many elements
+
+```bash
+cmux browser surface:7 snapshot --selector "form#checkout" --interactive
+```

--- a/claude/skills/cmux-browser/references/video-recording.md
+++ b/claude/skills/cmux-browser/references/video-recording.md
@@ -1,0 +1,52 @@
+# Video Recording
+
+Status and alternatives for capturing browser automation evidence in cmux.
+
+**Related**: [commands.md](commands.md), [SKILL.md](../SKILL.md)
+
+## Contents
+
+- [Current Status](#current-status)
+- [Recommended Alternatives](#recommended-alternatives)
+- [Use Cases](#use-cases)
+- [Best Practices](#best-practices)
+
+## Current Status
+
+`cmux browser` currently does not expose a built-in video recording command.
+
+Why: cmux browser automation runs on WKWebView, and the agent-browser style recording pipeline is Chrome/CDP-specific.
+
+## Recommended Alternatives
+
+### 1. Step Screenshots
+
+```bash
+cmux browser surface:7 screenshot > /tmp/step1.b64
+cmux browser surface:7 click e3 --snapshot-after --json
+cmux browser surface:7 screenshot > /tmp/step2.b64
+```
+
+### 2. Snapshot Timeline
+
+```bash
+cmux browser surface:7 snapshot --interactive > /tmp/snap-1.txt
+cmux browser surface:7 click e3 --snapshot-after --json > /tmp/action-1.json
+cmux browser surface:7 snapshot --interactive > /tmp/snap-2.txt
+```
+
+### 3. macOS Window Capture (external)
+
+Use an external screen recorder if full-motion capture is required.
+
+## Use Cases
+
+- Debug flaky browser automation.
+- Produce artifacts for CI logs.
+- Document flow changes between releases.
+
+## Best Practices
+
+1. Capture snapshot before and after each mutating action.
+2. Add `--snapshot-after` on clicks/fills/types that change state.
+3. Keep artifacts grouped by timestamp/run id.

--- a/claude/skills/cmux-browser/templates/authenticated-session.sh
+++ b/claude/skills/cmux-browser/templates/authenticated-session.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SURFACE="${1:-surface:1}"
+STATE_FILE="${2:-./auth-state.json}"
+DASHBOARD_URL="${3:-https://app.example.com/dashboard}"
+
+if [ -f "$STATE_FILE" ]; then
+  cmux browser "$SURFACE" state load "$STATE_FILE"
+fi
+
+cmux browser "$SURFACE" goto "$DASHBOARD_URL"
+cmux browser "$SURFACE" get url
+cmux browser "$SURFACE" wait --load-state complete --timeout-ms 15000
+cmux browser "$SURFACE" snapshot --interactive
+
+echo "If redirected to login, complete login flow then run:"
+echo "  cmux browser $SURFACE state save $STATE_FILE"

--- a/claude/skills/cmux-browser/templates/capture-workflow.sh
+++ b/claude/skills/cmux-browser/templates/capture-workflow.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SURFACE="${1:-surface:1}"
+OUT_DIR="${2:-./browser-artifacts}"
+mkdir -p "$OUT_DIR"
+
+TS="$(date +%Y%m%d-%H%M%S)"
+cmux browser "$SURFACE" snapshot --interactive > "$OUT_DIR/snapshot-$TS.txt"
+cmux browser "$SURFACE" screenshot > "$OUT_DIR/screenshot-$TS.b64"
+
+echo "Wrote: $OUT_DIR/snapshot-$TS.txt"
+echo "Wrote: $OUT_DIR/screenshot-$TS.b64"

--- a/claude/skills/cmux-browser/templates/form-automation.sh
+++ b/claude/skills/cmux-browser/templates/form-automation.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+URL="${1:-https://example.com/form}"
+SURFACE="${2:-surface:1}"
+
+cmux browser "$SURFACE" goto "$URL"
+cmux browser "$SURFACE" get url
+cmux browser "$SURFACE" wait --load-state complete --timeout-ms 15000
+cmux browser "$SURFACE" snapshot --interactive
+
+echo "Now run fill/click commands using refs from the snapshot above."

--- a/claude/skills/cmux-customization/SKILL.md
+++ b/claude/skills/cmux-customization/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: cmux-customization
+description: "Customize cmux for an end user. Use when changing cmux.json actions, custom commands, workspace layouts, plus-button behavior, surface tab bar buttons, Command Palette entries, Dock controls, sidebar and app settings, shortcuts, notifications, browser routing, examples-library presets, or Ghostty-backed terminal preferences."
+---
+
+# cmux Customization
+
+Use this skill for user-facing cmux customization. Keep the user's config intact, prefer schema-backed edits, and validate before reporting completion.
+
+## What Can Be Customized
+
+- Custom actions: define reusable `actions` in `cmux.json`. Actions can appear in Cmd+Shift+P, surface tab bars, shortcuts, and the plus-button right-click menu.
+- New workspace button: set `ui.newWorkspace.action` to replace the normal plus-button click, and `ui.newWorkspace.contextMenu` to control right-click actions. `ui.newWorkspace.rightClick` is accepted as an alias, but new examples should use `contextMenu`.
+- Surface tab bar buttons: set `ui.surfaceTabBar.buttons` to replace the default tab bar buttons. Include built-in IDs such as `cmux.newTerminal`, `cmux.newBrowser`, `cmux.splitRight`, and `cmux.splitDown` only when they should stay visible.
+- Workflows and layouts: use `commands` with workspace definitions to open a worktree, multiple checkouts, local services, browser previews, or SSH sessions in a deliberate split layout.
+- Dock controls: create `.cmux/dock.json` or `~/.config/cmux/dock.json` for right-sidebar terminal controls such as logs, test watchers, git TUIs, dev servers, queues, or `cmux feed tui --opentui`.
+- Sidebar and app behavior: use `cmux-settings` for supported settings such as appearance, sidebar display, notification behavior, browser routing, automation, shortcuts, and new-workspace placement.
+- Workspace metadata: use the cmux CLI or `cmux-workspace` for workspace names, descriptions, colors, read state, and sidebar metadata updates.
+- Feed and notifications: use `cmux hooks setup` for Feed event sources, notification settings for delivery behavior, and notification hooks in `cmux.json` for filtering or post-processing banners.
+- Team presets and examples: use project-local `.cmux/cmux.json` and `.cmux/dock.json` to share worktree, SSH, review, dev, CI, and docs workspace patterns with a repo.
+- Import, export, and reset: back up the current config, apply the smallest diff, validate it, and keep a rollback path for user-owned customizations.
+- Terminal behavior: use Ghostty config for fonts, themes, cursor style, copy-on-select, shell integration, terminal keybindings, and terminal rendering.
+
+## Choose the Right Surface
+
+- cmux app preferences: use `cmux-settings` for global `~/.config/cmux/cmux.json` settings such as appearance, sidebar, notifications, browser behavior, automation, and shortcuts.
+- Custom actions, workspace layouts, tab bar buttons, plus-button behavior, and Command Palette entries: edit `~/.config/cmux/cmux.json` globally or `.cmux/cmux.json` in the project. Project-local actions and commands override global entries with the same ID or name.
+- Dock controls: edit `.cmux/dock.json` in the project or `~/.config/cmux/dock.json` globally. Run `cmux docs dock` when available.
+- Terminal rendering and terminal keybindings: use Ghostty config, usually `~/.config/ghostty/config`. This includes fonts, cursor style, copy-on-select, shell integration, themes, and terminal keybindings.
+- Project-specific behavior: prefer `.cmux/cmux.json` in the project so actions, commands, UI action wiring, and notification hooks travel with the repo. Do not put global app preferences there.
+
+If a request can be handled by Ghostty config, say that and use Ghostty config instead of inventing cmux UI settings.
+
+## Examples Library
+
+For reusable patterns such as worktree agents, full-stack dev layouts, SSH
+devboxes, PR review workspaces, docs workspaces, quick agent tab buttons, and
+CI watches, read `references/examples.md`. Load it when the user asks for examples, presets,
+templates, starter configs, or a known workflow shape.
+
+## Workflow
+
+1. Inspect existing config before editing.
+
+   ```bash
+   test -f ~/.config/cmux/cmux.json && sed -n '1,220p' ~/.config/cmux/cmux.json
+   test -f .cmux/cmux.json && sed -n '1,220p' .cmux/cmux.json
+   ```
+
+2. Pick global or project-local scope. Ask only when the choice changes behavior meaningfully. Default to project-local for repo-specific commands and global for app preferences.
+3. Before editing, back up the target file when it already exists:
+
+   ```bash
+   stamp="$(date +%Y%m%d-%H%M%S)"
+   test -f ~/.config/cmux/cmux.json && cp -p ~/.config/cmux/cmux.json ~/.config/cmux/cmux.json."$stamp".bak
+   test -f .cmux/cmux.json && cp -p .cmux/cmux.json .cmux/cmux.json."$stamp".bak
+   ```
+
+   Use the applicable path only. Do not create a backup for a missing file.
+4. For app settings and cmux-owned shortcuts, use the settings helper from the installed skill or checkout:
+
+   ```bash
+   ~/.agents/skills/cmux-settings/scripts/cmux-settings list-supported
+   ~/.agents/skills/cmux-settings/scripts/cmux-settings set browser.openTerminalLinksInCmuxBrowser true
+   ~/.agents/skills/cmux-settings/scripts/cmux-settings validate
+   ```
+
+   If the user installed with `skills.sh`, use `~/.codex/skills/cmux-settings/scripts/cmux-settings` instead.
+5. For actions, UI wiring, workspace layouts, notification hooks, and Dock controls, edit JSONC or JSON carefully. Preserve unrelated sections such as `vault`, `rightSidebar`, `commands`, `actions`, `ui`, and `notifications`.
+6. Reload config after successful edits:
+
+   ```bash
+   cmux reload-config
+   ```
+
+7. Verify the configured entrypoint exists. For shortcuts, read back the binding. For custom actions, confirm the action ID and where it should appear.
+
+## Common Patterns
+
+Add a Command Palette action that opens Codex in a new tab. It will appear in Cmd+Shift+P unless `palette` is false:
+
+```json
+{
+  "actions": {
+    "codex-new-tab": {
+      "type": "agent",
+      "agent": "codex",
+      "title": "Codex",
+      "subtitle": "Start Codex in this workspace",
+      "target": "newTabInCurrentPane",
+      "palette": true
+    }
+  }
+}
+```
+
+Replace the plus-button click and define the plus-button right-click menu.
+This is the pattern for "bring your own worktree, multiple checkouts, or SSH
+setup". The `workspaceCommand` action ID is `worktree-agents`, and its
+`commandName` must match a command named `Worktree Agents` in the same config:
+
+```json
+{
+  "actions": {
+    "worktree-agents": {
+      "type": "workspaceCommand",
+      "title": "Worktree Agents",
+      "commandName": "Worktree Agents",
+      "icon": { "type": "symbol", "name": "folder.badge.plus" }
+    }
+  },
+  "ui": {
+    "newWorkspace": {
+      "action": "worktree-agents",
+      "contextMenu": [
+        { "action": "worktree-agents", "title": "Worktree Agents" },
+        { "type": "separator" },
+        { "action": "cmux.newTerminal", "title": "New Terminal" },
+        { "action": "cmux.newBrowser", "title": "New Browser" }
+      ]
+    }
+  },
+  "commands": [
+    {
+      "name": "Worktree Agents",
+      "description": "Create a worktree and open agents inside it",
+      "workspace": {
+        "name": "Worktree Agents",
+        "cwd": "../worktrees/my-feature",
+        "layout": {
+          "direction": "horizontal",
+          "children": [
+            {
+              "pane": {
+                "surfaces": [
+                  { "type": "terminal", "name": "Codex", "command": "codex" }
+                ]
+              }
+            },
+            {
+              "pane": {
+                "surfaces": [
+                  { "type": "terminal", "name": "SSH", "command": "ssh devbox" }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+Add a project workspace layout:
+
+```json
+{
+  "commands": [
+    {
+      "name": "dev",
+      "workspace": {
+        "name": "Dev",
+        "cwd": ".",
+        "layout": {
+          "direction": "horizontal",
+          "children": [
+            { "pane": { "surfaces": [{ "type": "terminal", "command": "bun dev" }] } },
+            { "pane": { "surfaces": [{ "type": "browser", "url": "http://localhost:3000" }] } }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+Replace surface tab bar buttons:
+
+```json
+{
+  "ui": {
+    "surfaceTabBar": {
+      "buttons": [
+        "cmux.newTerminal",
+        "cmux.newBrowser",
+        {
+          "action": "codex-new-tab",
+          "title": "Codex",
+          "icon": { "type": "symbol", "name": "terminal" }
+        }
+      ]
+    }
+  }
+}
+```
+
+Add project Dock controls:
+
+```json
+{
+  "controls": [
+    {
+      "id": "git",
+      "title": "Git",
+      "command": "lazygit",
+      "cwd": ".",
+      "height": 300
+    },
+    {
+      "id": "feed",
+      "title": "Feed",
+      "command": "cmux feed tui --opentui",
+      "height": 260
+    }
+  ]
+}
+```
+
+## Validation
+
+- App settings: run `cmux-settings validate`.
+- JSONC shape: keep valid JSONC and avoid duplicate keys.
+- Dock JSON: parse `.cmux/dock.json` or `~/.config/cmux/dock.json` with a JSON parser before reporting completion.
+- Runtime reload: run `cmux reload-config` when the CLI is available.
+- User-facing action: confirm the action title, shortcut, plus-button behavior, context-menu entry, or tab bar placement the user asked for.
+
+## Rules
+
+- Do not overwrite whole top-level config sections unless you own the full section.
+- Do not store secrets directly in actions, commands, or prompts. Use environment variables or the user's secret manager.
+- Do not use app/runtime sleeps or timing workarounds in generated commands.
+- Do not add a cmux setting for behavior Ghostty already owns.
+- Keep labels short enough for menus, buttons, and the Command Palette.

--- a/claude/skills/cmux-customization/agents/openai.yaml
+++ b/claude/skills/cmux-customization/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cmux Customization"
+  short_description: "Customize cmux actions, UI, layouts, and presets."
+  default_prompt: "Use $cmux-customization to pick an examples-library preset, wire it into cmux.json, and validate the cmux config."

--- a/claude/skills/cmux-customization/references/examples.md
+++ b/claude/skills/cmux-customization/references/examples.md
@@ -1,0 +1,338 @@
+# cmux Customization Examples
+
+Use these examples as starting points. Merge only the relevant top-level keys
+into the target config file named above each code block. Unlabeled JSON examples
+target `cmux.json`. Preserve unrelated sections, then run `cmux reload-config`
+when available.
+
+Prefer project-local `.cmux/cmux.json` for team workflows and global
+`~/.config/cmux/cmux.json` for personal app preferences.
+
+## Worktree Agents
+
+Use this when the user wants the plus button to open a worktree or checkout
+layout, and right-click to offer alternate starters.
+
+```json
+{
+  "actions": {
+    "worktree-agents": {
+      "type": "workspaceCommand",
+      "title": "Worktree Agents",
+      "commandName": "Worktree Agents",
+      "icon": { "type": "symbol", "name": "folder.badge.plus" }
+    }
+  },
+  "ui": {
+    "newWorkspace": {
+      "action": "worktree-agents",
+      "contextMenu": [
+        { "action": "worktree-agents", "title": "Worktree Agents" },
+        { "type": "separator" },
+        { "action": "cmux.newTerminal", "title": "New Terminal" },
+        { "action": "cmux.newBrowser", "title": "New Browser" }
+      ]
+    }
+  },
+  "commands": [
+    {
+      "name": "Worktree Agents",
+      "workspace": {
+        "name": "Worktree Agents",
+        "cwd": "../worktrees/my-feature",
+        "layout": {
+          "direction": "horizontal",
+          "children": [
+            {
+              "pane": {
+                "surfaces": [
+                  { "type": "terminal", "name": "Codex", "command": "codex" }
+                ]
+              }
+            },
+            {
+              "pane": {
+                "surfaces": [
+                  { "type": "terminal", "name": "Claude", "command": "claude" }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+## Full-Stack Dev
+
+Use this when a repo needs terminals, browser preview, and persistent Dock
+controls for repeated local development.
+
+`.cmux/cmux.json`:
+
+```json
+{
+  "commands": [
+    {
+      "name": "Full-Stack Dev",
+      "workspace": {
+        "name": "Dev",
+        "cwd": ".",
+        "layout": {
+          "direction": "horizontal",
+          "split": 0.55,
+          "children": [
+            {
+              "direction": "vertical",
+              "children": [
+                {
+                  "pane": {
+                    "surfaces": [
+                      { "type": "terminal", "name": "Web", "command": "bun dev" }
+                    ]
+                  }
+                },
+                {
+                  "pane": {
+                    "surfaces": [
+                      { "type": "terminal", "name": "Tests", "command": "bun test --watch" }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "pane": {
+                "surfaces": [
+                  { "type": "browser", "name": "Preview", "url": "http://localhost:3000" }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+`.cmux/dock.json`:
+
+```json
+{
+  "controls": [
+    { "id": "git", "title": "Git", "command": "lazygit", "cwd": ".", "height": 320 },
+    { "id": "feed", "title": "Feed", "command": "cmux feed tui --opentui", "height": 260 }
+  ]
+}
+```
+
+## SSH Devbox
+
+Use this when the user's normal environment is remote, or when local cmux should
+open a known SSH session beside project notes or a browser preview.
+
+```json
+{
+  "commands": [
+    {
+      "name": "SSH Devbox",
+      "keywords": ["ssh", "remote", "devbox"],
+      "workspace": {
+        "name": "Devbox",
+        "cwd": ".",
+        "layout": {
+          "direction": "horizontal",
+          "children": [
+            {
+              "pane": {
+                "surfaces": [
+                  { "type": "terminal", "name": "SSH", "command": "ssh devbox" }
+                ]
+              }
+            },
+            {
+              "pane": {
+                "surfaces": [
+                  { "type": "browser", "name": "Preview", "url": "http://localhost:3000" }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+## Review PR
+
+Use this when a project needs one command to review a pull request with a
+terminal, browser, and notes panel. Adjust the URL and command for the user's
+GitHub workflow.
+
+```json
+{
+  "commands": [
+    {
+      "name": "Review PR",
+      "keywords": ["review", "pull request", "pr"],
+      "workspace": {
+        "name": "PR Review",
+        "cwd": ".",
+        "layout": {
+          "direction": "horizontal",
+          "children": [
+            {
+              "pane": {
+                "surfaces": [
+                  { "type": "terminal", "name": "GitHub", "command": "gh pr status" }
+                ]
+              }
+            },
+            {
+              "pane": {
+                "surfaces": [
+                  { "type": "browser", "name": "Pull Request", "url": "https://github.com/owner/repo/pulls" }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+## Docs Workspace
+
+Use this when a repo needs one command for docs authoring with a dev server,
+browser preview, and markdown viewer. Adjust the command, URL, and markdown path
+for the docs stack.
+
+```json
+{
+  "commands": [
+    {
+      "name": "Docs Workspace",
+      "keywords": ["docs", "documentation", "preview"],
+      "workspace": {
+        "name": "Docs",
+        "cwd": ".",
+        "layout": {
+          "direction": "horizontal",
+          "split": 0.45,
+          "children": [
+            {
+              "direction": "vertical",
+              "children": [
+                {
+                  "pane": {
+                    "surfaces": [
+                      { "type": "terminal", "name": "Docs Server", "command": "bun run docs:dev" }
+                    ]
+                  }
+                },
+                {
+                  "pane": {
+                    "surfaces": [
+                      {
+                        "type": "terminal",
+                        "name": "Markdown",
+                        "command": "cmux markdown open docs/README.md --direction right --focus false; exec ${SHELL:-/bin/zsh} -l"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "pane": {
+                "surfaces": [
+                  { "type": "browser", "name": "Docs Preview", "url": "http://localhost:3000/docs" }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+## Quick Agent Buttons
+
+Use this when the user wants tab bar buttons for common agents while keeping
+the default new terminal and browser buttons.
+
+```json
+{
+  "actions": {
+    "codex-new-tab": {
+      "type": "agent",
+      "agent": "codex",
+      "title": "Codex",
+      "target": "newTabInCurrentPane",
+      "palette": true
+    },
+    "claude-new-tab": {
+      "type": "agent",
+      "agent": "claude",
+      "title": "Claude",
+      "target": "newTabInCurrentPane",
+      "palette": true
+    }
+  },
+  "ui": {
+    "surfaceTabBar": {
+      "buttons": [
+        "cmux.newTerminal",
+        "cmux.newBrowser",
+        { "action": "codex-new-tab", "title": "Codex" },
+        { "action": "claude-new-tab", "title": "Claude" }
+      ]
+    }
+  }
+}
+```
+
+## CI Watch
+
+Use this when the user wants a repeatable place for GitHub Actions, CircleCI,
+or release-monitoring commands. Prefer Dock controls for long-running monitors.
+
+`.cmux/dock.json`:
+
+```json
+{
+  "controls": [
+    {
+      "id": "gh-runs",
+      "title": "GitHub Runs",
+      "command": "gh run list --limit 10 && exec ${SHELL:-/bin/zsh} -l",
+      "cwd": ".",
+      "height": 260
+    },
+    {
+      "id": "feed",
+      "title": "Feed",
+      "command": "cmux feed tui --opentui",
+      "height": 260
+    }
+  ]
+}
+```
+
+## Validation Checklist
+
+- Parse any changed JSON or JSONC before reporting success.
+- Keep `cwd` inside the `workspace` object for workspace commands.
+- Confirm `workspaceCommand.commandName` matches a `commands[].name`.
+- Use `ui.newWorkspace.contextMenu` in new examples, not the alias.
+- Keep built-in tab bar buttons only when the user wants them visible.
+- Keep secrets out of config. Use shell profiles, env vars, or a secret store.

--- a/claude/skills/cmux-diagnostics/SKILL.md
+++ b/claude/skills/cmux-diagnostics/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: cmux-diagnostics
+description: "Run end-user cmux diagnostics. Use when cmux hooks, notifications, session restore, settings, browser automation, socket access, CLI control, or agent resume behavior is not working, or when the user asks for a cmux health check, doctor report, or support-safe debug summary."
+---
+
+# cmux Diagnostics
+
+Use this skill to collect and interpret support-safe cmux diagnostics for end users. Default to read-only checks. Do not dump hook config files, session stores, prompt logs, tokens, or environment secrets.
+
+## Quick Report
+
+Run the bundled read-only diagnostic script first:
+
+```bash
+# From a cmux checkout
+skills/cmux-diagnostics/scripts/cmux-diagnostics
+
+# From an installed skill
+~/.agents/skills/cmux-diagnostics/scripts/cmux-diagnostics
+
+# From a Codex-only skills.sh install
+~/.codex/skills/cmux-diagnostics/scripts/cmux-diagnostics
+```
+
+Use `--include-context` only when workspace names, cwd paths, and current cmux identifiers are relevant to the user-reported issue:
+
+```bash
+skills/cmux-diagnostics/scripts/cmux-diagnostics --include-context
+```
+
+## What to Check
+
+1. CLI and socket health:
+
+   ```bash
+   command -v cmux
+   cmux ping
+   cmux capabilities --json
+   ```
+
+   If socket commands fail, check whether the agent is running inside a cmux terminal and whether socket automation is enabled.
+
+2. Settings health:
+
+   ```bash
+   ~/.agents/skills/cmux-settings/scripts/cmux-settings validate
+   ~/.agents/skills/cmux-settings/scripts/cmux-settings get terminal.autoResumeAgentSessions
+   ```
+
+   If the user installed with `skills.sh`, use `~/.codex/skills/cmux-settings/scripts/cmux-settings` instead.
+   If `terminal.autoResumeAgentSessions` is false, cmux restores panes but will not automatically resume saved agent sessions.
+
+3. Hook installation:
+
+   ```bash
+   cmux hooks setup --agent codex
+   cmux hooks setup --agent opencode
+   cmux hooks setup
+   ```
+
+   Only run install or uninstall commands after the user agrees. `cmux hooks setup` installs supported agents found on PATH and skips missing agents.
+
+4. Session restore evidence:
+
+   ```bash
+   ls -lh ~/.cmuxterm/*-hook-sessions.json 2>/dev/null
+   ```
+
+   Missing session stores usually means the agent has not run inside cmux since hooks were installed, hooks are disabled, or the agent integration does not support resume capture.
+
+5. Notification path:
+
+   ```bash
+   cmux notify "cmux diagnostic test"
+   ```
+
+   Use this only when the user is ready for a visible test notification.
+
+## Interpretation
+
+- `cmux` not found: the CLI is not installed or not on PATH for this shell.
+- `cmux ping` fails: app is not reachable through the current socket path, the app is closed, or automation access is disabled.
+- No `CMUX_WORKSPACE_ID` or `CMUX_SURFACE_ID`: the command is probably running outside a cmux terminal. Some hooks intentionally no-op outside cmux.
+- Hook config exists but no session store: run one supported agent inside cmux after installing hooks, then re-check.
+- Session store exists but restore does not launch agents: check `terminal.autoResumeAgentSessions` and whether the saved executable still exists on PATH.
+- Settings validation fails: fix the config first. Invalid config can make later symptoms misleading.
+
+## Rules
+
+- Stay read-only until the user asks to fix something.
+- Never print raw hook files, session JSON, prompt logs, shell history, tokens, or API keys.
+- Summarize file presence, size, modified time, and marker presence instead of contents.
+- Prefer narrow fixes such as `cmux hooks setup --agent codex` over reinstalling every integration.
+- After a fix, rerun the diagnostic script and report the changed lines.

--- a/claude/skills/cmux-diagnostics/agents/openai.yaml
+++ b/claude/skills/cmux-diagnostics/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cmux Diagnostics"
+  short_description: "Check cmux hooks, restore, CLI, and settings."
+  default_prompt: "Use $cmux-diagnostics to collect a read-only cmux health report and explain any hook or session restore problems."

--- a/claude/skills/cmux-diagnostics/scripts/cmux-diagnostics
+++ b/claude/skills/cmux-diagnostics/scripts/cmux-diagnostics
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+include_context=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --include-context)
+      include_context=1
+      shift
+      ;;
+    -h|--help)
+      cat <<'EOF'
+Usage: cmux-diagnostics [--include-context]
+
+Print a read-only, support-safe cmux diagnostics report. By default this avoids
+workspace names, cwd paths, hook contents, session JSON, and secrets.
+EOF
+      exit 0
+      ;;
+    *)
+      printf 'cmux-diagnostics: unknown option: %s\n' "$1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+section() {
+  printf '\n== %s ==\n' "$1"
+}
+
+safe_path() {
+  local path="$1"
+  if [[ "$path" == "$HOME" ]]; then
+    printf '~'
+  elif [[ "$path" == "$HOME"/* ]]; then
+    printf '~/%s' "${path#"$HOME"/}"
+  else
+    printf '%s' "$path"
+  fi
+}
+
+run_status() {
+  local label="$1"
+  shift
+  printf '%s: ' "$label"
+  if "$@" >/dev/null 2>&1; then
+    printf 'ok\n'
+  else
+    printf 'failed\n'
+  fi
+}
+
+file_summary() {
+  local path="$1"
+  if [[ -f "$path" ]]; then
+    local bytes modified
+    bytes="$(wc -c <"$path" 2>/dev/null | tr -d ' ' || true)"
+    modified="$(stat -f '%Sm' -t '%Y-%m-%d %H:%M:%S %z' "$path" 2>/dev/null || stat -c '%y' "$path" 2>/dev/null || printf 'unknown')"
+    printf 'present bytes=%s modified=%s\n' "${bytes:-unknown}" "$modified"
+  elif [[ -e "$path" ]]; then
+    printf 'non-regular\n'
+  else
+    printf 'missing\n'
+  fi
+}
+
+marker_summary() {
+  local path="$1"
+  local marker="$2"
+  if [[ -f "$path" ]]; then
+    if grep -Fq "$marker" "$path" 2>/dev/null; then
+      printf 'marker-present\n'
+    else
+      printf 'marker-missing\n'
+    fi
+  elif [[ -e "$path" ]]; then
+    printf 'non-regular\n'
+  else
+    printf 'missing\n'
+  fi
+}
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+skill_dir="$(cd -- "$script_dir/.." >/dev/null 2>&1 && pwd)"
+skills_root="$(cd -- "$skill_dir/.." >/dev/null 2>&1 && pwd)"
+settings_helper="$skills_root/cmux-settings/scripts/cmux-settings"
+if [[ ! -x "$settings_helper" && -x "$HOME/.agents/skills/cmux-settings/scripts/cmux-settings" ]]; then
+  settings_helper="$HOME/.agents/skills/cmux-settings/scripts/cmux-settings"
+elif [[ ! -x "$settings_helper" && -x "$HOME/.codex/skills/cmux-settings/scripts/cmux-settings" ]]; then
+  settings_helper="$HOME/.codex/skills/cmux-settings/scripts/cmux-settings"
+fi
+
+section "cmux diagnostics"
+printf 'date: %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+printf 'shell: %s\n' "${SHELL:-unknown}"
+printf 'inside_cmux: '
+if [[ -n "${CMUX_WORKSPACE_ID:-}" || -n "${CMUX_SURFACE_ID:-}" ]]; then
+  printf 'yes\n'
+else
+  printf 'no\n'
+fi
+printf 'cmux_workspace_id_set: %s\n' "$([[ -n "${CMUX_WORKSPACE_ID:-}" ]] && printf yes || printf no)"
+printf 'cmux_surface_id_set: %s\n' "$([[ -n "${CMUX_SURFACE_ID:-}" ]] && printf yes || printf no)"
+if [[ "${CMUX_SOCKET_PATH+x}" == "x" ]]; then
+  printf 'cmux_socket_path: %s (from CMUX_SOCKET_PATH)\n' "$(safe_path "$CMUX_SOCKET_PATH")"
+elif [[ "${CMUX_SOCKET+x}" == "x" ]]; then
+  printf 'cmux_socket_path: %s (from CMUX_SOCKET)\n' "$(safe_path "$CMUX_SOCKET")"
+else
+  printf 'cmux_socket_path: unset\n'
+fi
+printf 'cmux_socket_password_set: %s\n' "$([[ -n "${CMUX_SOCKET_PASSWORD:-}" ]] && printf yes || printf no)"
+
+section "cli"
+if command -v cmux >/dev/null 2>&1; then
+  printf 'cmux_path: %s\n' "$(safe_path "$(command -v cmux)")"
+  if cmux --version >/dev/null 2>&1; then
+    printf 'cmux_version: %s\n' "$(cmux --version 2>/dev/null | head -n 1)"
+  else
+    printf 'cmux_version: unavailable\n'
+  fi
+  run_status "cmux_ping" cmux ping
+  run_status "cmux_capabilities" cmux capabilities --json
+  if [[ "$include_context" -eq 1 ]]; then
+    printf 'identify_json:\n'
+    cmux identify --json 2>/dev/null || printf '  unavailable\n'
+  fi
+else
+  printf 'cmux_path: missing\n'
+fi
+
+section "settings"
+printf 'cmux_json: '
+file_summary "$HOME/.config/cmux/cmux.json"
+printf 'legacy_settings_json: '
+file_summary "$HOME/.config/cmux/settings.json"
+if [[ -x "$settings_helper" ]]; then
+  run_status "cmux_settings_validate" "$settings_helper" validate
+  printf 'auto_resume_agent_sessions: '
+  "$settings_helper" get terminal.autoResumeAgentSessions 2>/dev/null || printf 'default-or-unset\n'
+else
+  printf 'cmux_settings_helper: missing (%s)\n' "$(safe_path "$settings_helper")"
+fi
+
+section "hook configs"
+declare -a hook_checks=(
+  "codex:$HOME/.codex/hooks.json:cmux hooks codex"
+  "codex-config:$HOME/.codex/config.toml:codex_hooks"
+  "opencode-session:$HOME/.config/opencode/plugins/cmux-session.js:cmux hooks opencode"
+  "opencode-feed:$HOME/.config/opencode/plugins/cmux-feed.js:cmux hooks feed --source opencode"
+  "pi:$HOME/.pi/agent/extensions/cmux-session.ts:cmux hooks pi"
+  "amp:$HOME/.config/amp/plugins/cmux-session.ts:cmux hooks amp"
+  "cursor:$HOME/.cursor/hooks.json:cmux hooks cursor"
+  "gemini:$HOME/.gemini/settings.json:cmux hooks gemini"
+  "rovodev:$HOME/.rovodev/rovodev.yml:cmux hooks rovodev"
+  "hermes-agent:$HOME/.hermes/config.yaml:cmux hooks hermes-agent"
+  "copilot:$HOME/.copilot/settings.json:cmux hooks copilot"
+  "codebuddy:$HOME/.codebuddy/settings.json:cmux hooks codebuddy"
+  "factory:$HOME/.factory/settings.json:cmux hooks factory"
+  "qoder:$HOME/.qoder/settings.json:cmux hooks qoder"
+)
+for entry in "${hook_checks[@]}"; do
+  IFS=: read -r name path marker <<<"$entry"
+  printf '%s: %s ' "$name" "$(safe_path "$path")"
+  marker_summary "$path" "$marker"
+done
+
+section "session stores"
+shopt -s nullglob
+stores=("$HOME"/.cmuxterm/*-hook-sessions.json)
+if [[ "${#stores[@]}" -eq 0 ]]; then
+  printf 'session_store_files: none\n'
+else
+  printf 'session_store_files: %s\n' "${#stores[@]}"
+  for path in "${stores[@]}"; do
+    printf '%s: ' "$(basename "$path")"
+    file_summary "$path"
+  done
+fi
+
+section "agent binaries"
+for bin in claude codex opencode pi amp cursor-agent gemini rovo rovodev hermes-agent gh copilot codebuddy droid qodercli; do
+  if command -v "$bin" >/dev/null 2>&1; then
+    printf '%s: present (%s)\n' "$bin" "$(safe_path "$(command -v "$bin")")"
+  else
+    printf '%s: missing\n' "$bin"
+  fi
+done

--- a/claude/skills/cmux-keyboard-shortcuts/SKILL.md
+++ b/claude/skills/cmux-keyboard-shortcuts/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: cmux-keyboard-shortcuts
+description: "Guide and apply cmux keyboard shortcut customization. Use when the user asks to customize, rebind, unbind, reset, audit, or create shortcut templates for cmux, including tmux-style, Vim-style, terminal-first, browser-heavy, iTerm/Terminal-like, or agent-triage layouts."
+---
+
+# cmux-keyboard-shortcuts
+
+Use this skill to turn a user's workflow preferences into cmux shortcut bindings in `~/.config/cmux/cmux.json`. It should guide the user, propose compact templates, apply selected changes, and confirm the config parses with recognized keys.
+
+## Prerequisites
+
+- Work from a cmux checkout or worktree root when possible.
+- Use `skills/cmux-settings/scripts/cmux-settings` for every read/write. It reads JSONC, writes atomically, and validates JSON plus recognized settings keys.
+- For action IDs, read `skills/cmux-settings/references/shortcut-actions.md`.
+- For current defaults, read `web/data/cmux-shortcuts.ts` or `Sources/KeyboardShortcutSettings.swift`.
+
+```bash
+find_cmux_settings() {
+  local root
+  root="$(git -C "$(pwd)" rev-parse --show-toplevel 2>/dev/null || pwd)"
+  for candidate in \
+    "$root/skills/cmux-settings/scripts/cmux-settings" \
+    "${CODEX_HOME:-$HOME/.codex}/skills/cmux-settings/scripts/cmux-settings" \
+    "$HOME/.agents/skills/cmux-settings/scripts/cmux-settings"; do
+    if [[ -x "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+if [[ -z "${CMUX_SETTINGS:-}" ]]; then
+  CMUX_SETTINGS="$(find_cmux_settings)" || {
+    echo "cmux-settings helper not found; run from a cmux checkout or install cmux-settings" >&2
+    exit 1
+  }
+fi
+```
+
+## Shortcut Model
+
+- Setting path: `shortcuts.bindings.<actionId>`.
+- Single stroke: `"cmd+b"`.
+- Chord: `["ctrl+b","c"]`. The first stroke needs a modifier unless the key is Space. The second stroke can be bare.
+- Unbind: prefer `null` for explicit unbinds. `""`, `"none"`, `"clear"`, `"unbound"`, and `"disabled"` are accepted aliases, but `null` is the clearest JSON value and matches the templates below.
+- `selectSurfaceByNumber` and `selectWorkspaceByNumber` must use a digit from 1 to 9. `cmd+1` means the full `cmd+1` through `cmd+9` family.
+- `showHideAllWindows` and `globalSearch` are system-wide shortcuts. They cannot be chords, require modifiers, and may be rejected by macOS if reserved.
+- `showHideAllWindows` also requires Settings > Global Hotkey > Enable System-Wide Hotkey. The binding can validate in `cmux.json` while the feature is disabled, so warn the user to enable that setting before reporting the shortcut as usable.
+- `unset` deletes a `cmux.json` override. It does not clear shortcut changes saved through the Settings UI/UserDefaults. If the user asks for true built-in defaults, tell them to use Settings > Keyboard Shortcuts > Reset Default Shortcuts after clearing file-managed overrides, then verify in the app. For `showHideAllWindows`, use Settings > Global Hotkey to restore the shortcut to `ctrl+opt+cmd+.` because Keyboard Shortcuts > Reset Default Shortcuts intentionally skips the global hotkey.
+- Saving `cmux.json` live reloads. Do not tell the user to restart cmux.
+
+## Workflow
+
+1. Classify the request:
+   - One-off rebind or unbind: map the phrase to an action ID, apply it, validate, and report the previous and new binding.
+   - Audit-only request: inspect current bindings, validate, and summarize overrides/unbound shortcuts without writing.
+   - Reset request: clarify whether the user means file-managed overrides or true built-in defaults. For file-managed resets, use `unset` for named actions. For true built-in defaults, remove file overrides and direct the user to Settings > Keyboard Shortcuts > Reset Default Shortcuts; do not report built-in defaults restored from `cmux-settings` alone. If `showHideAllWindows` is included, also direct them to Settings > Global Hotkey to restore `ctrl+opt+cmd+.` and the enable toggle.
+   - Broad customization request: propose 3 to 5 templates from "Preset Templates" and ask the user to choose.
+   - Named style such as tmux, Vim, iTerm, browser, or agent triage: select the closest template, show the changed actions and likely collisions, and ask before a bulk apply unless the user explicitly said to apply it.
+2. Inspect existing config:
+
+   ```bash
+   "$CMUX_SETTINGS" path
+   "$CMUX_SETTINGS" get shortcuts.bindings 2>/dev/null || printf '{}\n'
+   "$CMUX_SETTINGS" validate
+   ```
+
+3. Before applying a template, snapshot prior values for every action you will change. A path that is absent must revert with `unset`; a path with an existing custom value must revert with `set <same-json-value>`.
+
+   ```bash
+   "$CMUX_SETTINGS" get shortcuts.bindings.focusLeft 2>/dev/null || printf '<absent>\n'
+   ```
+
+4. Apply only the chosen action paths:
+
+   ```bash
+   "$CMUX_SETTINGS" set shortcuts.bindings.newSurface '["ctrl+b","c"]'
+   "$CMUX_SETTINGS" set shortcuts.bindings.focusLeft cmd+opt+h
+   "$CMUX_SETTINGS" set shortcuts.bindings.sendFeedback null
+   "$CMUX_SETTINGS" validate
+   ```
+
+5. Verify readback for changed actions:
+
+   ```bash
+   "$CMUX_SETTINGS" get shortcuts.bindings.newSurface
+   ```
+
+6. Finish with the template name, changed actions, and exact revert commands from the snapshot. Use `unset` only for actions that were absent before the template; use `set` to restore previous custom bindings.
+
+## Preset Templates
+
+Use these as proposal templates. Apply them action by action, not by overwriting the whole `shortcuts.bindings` object.
+
+### Tmux Prefix
+
+For users who want one terminal-style shortcut namespace and accept that `ctrl+b` starts a cmux chord instead of going directly to the shell.
+
+```bash
+"$CMUX_SETTINGS" set shortcuts.bindings.newSurface '["ctrl+b","c"]'
+"$CMUX_SETTINGS" set shortcuts.bindings.closeTab '["ctrl+b","x"]'
+"$CMUX_SETTINGS" set shortcuts.bindings.nextSurface '["ctrl+b","n"]'
+"$CMUX_SETTINGS" set shortcuts.bindings.prevSurface '["ctrl+b","p"]'
+"$CMUX_SETTINGS" set shortcuts.bindings.selectSurfaceByNumber '["ctrl+b","1"]'
+"$CMUX_SETTINGS" set shortcuts.bindings.splitRight '["ctrl+b","v"]'
+"$CMUX_SETTINGS" set shortcuts.bindings.splitDown '["ctrl+b","s"]'
+"$CMUX_SETTINGS" set shortcuts.bindings.focusLeft '["ctrl+b","h"]'
+"$CMUX_SETTINGS" set shortcuts.bindings.focusDown '["ctrl+b","j"]'
+"$CMUX_SETTINGS" set shortcuts.bindings.focusUp '["ctrl+b","k"]'
+"$CMUX_SETTINGS" set shortcuts.bindings.focusRight '["ctrl+b","l"]'
+"$CMUX_SETTINGS" set shortcuts.bindings.toggleSplitZoom '["ctrl+b","z"]'
+"$CMUX_SETTINGS" set shortcuts.bindings.toggleTerminalCopyMode '["ctrl+b","["]'
+"$CMUX_SETTINGS" set shortcuts.bindings.equalizeSplits '["ctrl+b","="]'
+```
+
+### macOS Terminal/iTerm Restore
+
+For users who want surface, split, and tab behavior to feel like common macOS terminals again. These actions already match cmux built-in defaults when no Settings UI override exists, so unset file overrides instead of writing default values.
+
+```bash
+"$CMUX_SETTINGS" unset shortcuts.bindings.newSurface
+"$CMUX_SETTINGS" unset shortcuts.bindings.closeTab
+"$CMUX_SETTINGS" unset shortcuts.bindings.nextSurface
+"$CMUX_SETTINGS" unset shortcuts.bindings.prevSurface
+"$CMUX_SETTINGS" unset shortcuts.bindings.selectSurfaceByNumber
+"$CMUX_SETTINGS" unset shortcuts.bindings.splitRight
+"$CMUX_SETTINGS" unset shortcuts.bindings.splitDown
+"$CMUX_SETTINGS" unset shortcuts.bindings.toggleSplitZoom
+"$CMUX_SETTINGS" unset shortcuts.bindings.toggleTerminalCopyMode
+"$CMUX_SETTINGS" unset shortcuts.bindings.renameTab
+```
+
+### Vim Pane Navigation
+
+For users who want fast pane movement without a prefix and do not want to depend on arrow keys.
+
+```bash
+"$CMUX_SETTINGS" set shortcuts.bindings.focusLeft cmd+opt+h
+"$CMUX_SETTINGS" set shortcuts.bindings.focusDown cmd+opt+j
+"$CMUX_SETTINGS" set shortcuts.bindings.focusUp cmd+opt+k
+"$CMUX_SETTINGS" set shortcuts.bindings.focusRight cmd+opt+l
+"$CMUX_SETTINGS" set shortcuts.bindings.splitRight cmd+opt+v
+"$CMUX_SETTINGS" set shortcuts.bindings.splitDown cmd+opt+s
+"$CMUX_SETTINGS" set shortcuts.bindings.toggleSplitZoom cmd+opt+z
+"$CMUX_SETTINGS" set shortcuts.bindings.equalizeSplits cmd+opt+=
+```
+
+### Agent Triage
+
+For users who live in notifications and want unread handling on one key family. This keeps toggle unread on `cmd+opt+u` so it can be combined with Vim Pane Navigation without colliding with `cmd+opt+j`.
+
+```bash
+"$CMUX_SETTINGS" set shortcuts.bindings.showNotifications cmd+u
+"$CMUX_SETTINGS" set shortcuts.bindings.jumpToUnread cmd+j
+"$CMUX_SETTINGS" set shortcuts.bindings.markOldestUnreadAndJumpNext cmd+shift+j
+"$CMUX_SETTINGS" set shortcuts.bindings.toggleUnread cmd+opt+u
+"$CMUX_SETTINGS" set shortcuts.bindings.triggerFlash cmd+shift+h
+"$CMUX_SETTINGS" set shortcuts.bindings.focusRightSidebar cmd+shift+e
+```
+
+### Workspace And Surface Lanes
+
+For users who want workspaces and surfaces on distinct number and bracket lanes.
+
+```bash
+"$CMUX_SETTINGS" set shortcuts.bindings.selectWorkspaceByNumber cmd+1
+"$CMUX_SETTINGS" set shortcuts.bindings.selectSurfaceByNumber cmd+opt+1
+"$CMUX_SETTINGS" set shortcuts.bindings.nextSidebarTab 'cmd+opt+]'
+"$CMUX_SETTINGS" set shortcuts.bindings.prevSidebarTab 'cmd+opt+['
+"$CMUX_SETTINGS" set shortcuts.bindings.nextSurface 'cmd+shift+]'
+"$CMUX_SETTINGS" set shortcuts.bindings.prevSurface 'cmd+shift+['
+```
+
+### Browser Defaults Restore
+
+For users who changed too much and want embedded-browser behavior to match common macOS browser shortcuts again. Use `unset` to clear file overrides so future cmux defaults still apply when no Settings UI override exists.
+
+```bash
+"$CMUX_SETTINGS" unset shortcuts.bindings.openBrowser
+"$CMUX_SETTINGS" unset shortcuts.bindings.focusBrowserAddressBar
+"$CMUX_SETTINGS" unset shortcuts.bindings.browserBack
+"$CMUX_SETTINGS" unset shortcuts.bindings.browserForward
+"$CMUX_SETTINGS" unset shortcuts.bindings.browserReload
+"$CMUX_SETTINGS" unset shortcuts.bindings.browserZoomIn
+"$CMUX_SETTINGS" unset shortcuts.bindings.browserZoomOut
+"$CMUX_SETTINGS" unset shortcuts.bindings.browserZoomReset
+"$CMUX_SETTINGS" unset shortcuts.bindings.toggleBrowserDeveloperTools
+"$CMUX_SETTINGS" unset shortcuts.bindings.showBrowserJavaScriptConsole
+"$CMUX_SETTINGS" unset shortcuts.bindings.find
+"$CMUX_SETTINGS" unset shortcuts.bindings.findNext
+"$CMUX_SETTINGS" unset shortcuts.bindings.findPrevious
+```
+
+### Terminal-First Cleanup
+
+For users who want fewer app-level shortcuts. Prefer unbinding only the actions they name, but this is a reasonable starting proposal.
+
+```bash
+"$CMUX_SETTINGS" set shortcuts.bindings.renameTab null
+"$CMUX_SETTINGS" set shortcuts.bindings.renameWorkspace null
+"$CMUX_SETTINGS" set shortcuts.bindings.editWorkspaceDescription null
+"$CMUX_SETTINGS" set shortcuts.bindings.triggerFlash null
+"$CMUX_SETTINGS" set shortcuts.bindings.sendFeedback null
+```
+
+## Rules
+
+- Do not edit `~/.config/cmux/settings.json` unless the user explicitly asks. It is legacy fallback config.
+- Do not overwrite all of `shortcuts.bindings` unless the user explicitly wants a full replacement.
+- Do not invent action IDs. Validate against the schema or `shortcut-actions.md`.
+- Do not apply a broad template without showing the changed actions first unless the user explicitly said to apply that named template.
+- Do not promise conflict detection from `cmux-settings validate`; it validates JSON and supported keys, not shortcut syntax, macOS reservation, or every focus-context conflict.
+- Before assigning `cmd+[` or `cmd+]` to application-scoped actions, warn that they collide with common browser Back/Forward behavior unless the browser actions are also changed or unbound.
+- Prefer `unset` to clear file-managed overrides for individual actions. Do not call this a built-in default reset unless Settings UI/UserDefaults values have also been reset:
+
+  ```bash
+  "$CMUX_SETTINGS" unset shortcuts.bindings.focusLeft
+  "$CMUX_SETTINGS" validate
+  ```

--- a/claude/skills/cmux-keyboard-shortcuts/agents/openai.yaml
+++ b/claude/skills/cmux-keyboard-shortcuts/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cmux Keyboard Shortcuts"
+  short_description: "Customize cmux shortcuts and preset layouts."
+  default_prompt: "Use this skill to help choose and apply cmux keyboard shortcut templates: inspect current bindings, propose layouts, apply selected action paths, validate cmux.json, and report exact revert commands."

--- a/claude/skills/cmux-markdown/SKILL.md
+++ b/claude/skills/cmux-markdown/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: cmux-markdown
+description: Open markdown files in a formatted viewer panel with live reload. Use when you need to display plans, documentation, or notes alongside the terminal with rich rendering (headings, code blocks, tables, lists).
+---
+
+# Markdown Viewer with cmux
+
+Use this skill to display markdown files in a dedicated panel with rich formatting and live file watching.
+
+## Core Workflow
+
+1. Write your plan or notes to a `.md` file.
+2. Open it in a markdown panel.
+3. The panel auto-updates when the file changes on disk.
+
+```bash
+# Open a markdown file as a split panel next to the current terminal
+cmux markdown open plan.md
+
+# Absolute path
+cmux markdown open /path/to/PLAN.md
+
+# Target a specific workspace
+cmux markdown open design.md --workspace workspace:2
+```
+
+## When to Use
+
+- Displaying an agent plan or task list alongside the terminal
+- Showing documentation, changelogs, or READMEs while working
+- Reviewing notes that update in real-time (e.g., a plan file being written by another process)
+
+## Live File Watching
+
+The panel automatically re-renders when the file changes on disk. This works with:
+
+- Direct writes (`echo "..." >> plan.md`)
+- Editor saves (vim, nano, VS Code)
+- Atomic file replacement (write to temp, rename over original)
+- Agent-generated plan files that are updated progressively
+
+If the file is deleted, the panel shows a "file unavailable" state. During atomic replace, the panel attempts automatic reconnection within its short retry window. If the file returns later, close and reopen the panel.
+
+## Agent Integration
+
+### Opening a plan file
+
+Write your plan to a file, then open it:
+
+```bash
+cat > plan.md << 'EOF'
+# Task Plan
+
+## Steps
+1. Analyze the codebase
+2. Implement the feature
+3. Write tests
+4. Verify the build
+EOF
+
+cmux markdown open plan.md
+```
+
+### Updating a plan in real-time
+
+The panel live-reloads, so simply overwrite the file as work progresses:
+
+```bash
+# The markdown panel updates automatically when the file changes
+echo "## Step 1: Complete" >> plan.md
+```
+
+### Recommended AGENTS.md instruction
+
+Add this to your project's `AGENTS.md` to instruct coding agents to use the markdown viewer:
+
+```markdown
+## Plan Display
+
+When creating a plan or task list, write it to a `.md` file and open it in cmux:
+
+    cmux markdown open plan.md
+
+The panel renders markdown with rich formatting and auto-updates when the file changes.
+```
+
+## Routing
+
+```bash
+# Open in the caller's workspace (default -- uses CMUX_WORKSPACE_ID)
+cmux markdown open plan.md
+
+# Open in a specific workspace
+cmux markdown open plan.md --workspace workspace:2
+
+# Open splitting from a specific surface
+cmux markdown open plan.md --surface surface:5
+
+# Open in a specific window
+cmux markdown open plan.md --window window:1
+```
+
+## Deep-Dive References
+
+| Reference | When to Use |
+|-----------|-------------|
+| [references/commands.md](references/commands.md) | Full command syntax and options |
+| [references/live-reload.md](references/live-reload.md) | File watching behavior, atomic writes, edge cases |
+
+## Rendering Support
+
+The markdown panel renders:
+
+- Headings (h1-h6) with dividers on h1/h2
+- Fenced code blocks with monospaced font
+- Inline code with highlighted background
+- Tables with alternating row colors
+- Ordered and unordered lists (nested)
+- Blockquotes with left border
+- Bold, italic, strikethrough
+- Links (clickable)
+- Horizontal rules
+- Images (inline)
+
+Supports both light and dark mode.

--- a/claude/skills/cmux-markdown/agents/openai.yaml
+++ b/claude/skills/cmux-markdown/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cmux Markdown Viewer"
+  short_description: "Open markdown files in a formatted panel with live reload alongside the terminal."
+  default_prompt: "Use this skill to display markdown plans, docs, or notes in a cmux panel: write to a .md file, run 'cmux markdown open <path>', and the panel auto-updates when the file changes."

--- a/claude/skills/cmux-markdown/references/commands.md
+++ b/claude/skills/cmux-markdown/references/commands.md
@@ -1,0 +1,69 @@
+# Command Reference (cmux Markdown)
+
+## Opening a Markdown Panel
+
+```bash
+cmux markdown open <path>
+cmux markdown <path>          # shorthand (implicit "open")
+```
+
+### Options
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--workspace <id\|ref\|index>` | Target workspace | `$CMUX_WORKSPACE_ID` |
+| `--surface <id\|ref\|index>` | Source surface to split from | Focused surface |
+| `--window <id\|ref>` | Target window | Current window |
+
+### Output
+
+```
+OK surface=surface:8 pane=pane:3 path=/absolute/path/to/file.md
+```
+
+With `--json`:
+
+```json
+{
+  "window_id": "...",
+  "workspace_id": "...",
+  "pane_id": "...",
+  "surface_id": "...",
+  "path": "/absolute/path/to/file.md"
+}
+```
+
+## Path Resolution
+
+- Relative paths are resolved against the caller's current working directory.
+- `~` is expanded to the home directory.
+- The resolved absolute path is returned in the output.
+
+```bash
+# These are equivalent when run from /Users/me/project
+cmux markdown open plan.md
+cmux markdown open ./plan.md
+cmux markdown open /Users/me/project/plan.md
+```
+
+## Panel Behavior
+
+- The panel opens as a **horizontal split** to the right of the source surface.
+- The tab title shows the filename (e.g., `plan.md`).
+- The tab icon is a document icon.
+- Content is **read-only** with text selection enabled.
+- The file path is displayed as a breadcrumb at the top of the panel.
+
+## Session Persistence
+
+Markdown panels are saved and restored across sessions. On restore, the panel re-reads the file from disk. If the file no longer exists at restore time, the panel is not recreated.
+
+## Help
+
+```bash
+cmux markdown --help
+cmux markdown -h
+```
+
+See also:
+- [live-reload.md](live-reload.md)

--- a/claude/skills/cmux-markdown/references/live-reload.md
+++ b/claude/skills/cmux-markdown/references/live-reload.md
@@ -1,0 +1,53 @@
+# Live Reload Behavior
+
+The markdown panel watches the file on disk and automatically re-renders when it changes. This enables real-time plan tracking as agents or editors update the file.
+
+## How It Works
+
+The panel uses a kernel-level file system watcher (`DispatchSource` with `O_EVTONLY`) that monitors the file for:
+
+- **Write events** -- content was modified in place
+- **Extend events** -- content was appended
+- **Delete events** -- file was removed (atomic replace step 1)
+- **Rename events** -- file was moved or renamed
+
+## Supported Write Patterns
+
+| Pattern | Supported | Notes |
+|---------|-----------|-------|
+| Direct write (`echo >>`) | Yes | Triggers write/extend event |
+| Editor save (vim, nano) | Yes | Most editors use atomic write (see below) |
+| Atomic replace (write tmp + rename) | Yes | Handled via delete/rename recovery |
+| `sed -i` | Yes | Uses atomic replace internally |
+| VS Code / IDE save | Yes | Uses atomic replace |
+| Agent progressive writes | Yes | Each write triggers a re-render |
+
+## Atomic File Replacement
+
+Many editors and tools write files atomically: write to a temporary file, then rename it over the original. This shows up as a **delete** event followed by a new file appearing at the same path.
+
+The panel handles this by:
+
+1. Detecting the delete/rename event
+2. Attempting to re-read the file immediately (in case the rename already happened)
+3. If the file is missing, wait 500 ms and check again (the new file may not yet be in place)
+4. Reconnecting the file watcher to the new inode
+
+## File Unavailable State
+
+If the file is deleted and does not reappear within the retry window, the panel shows a "file unavailable" state with the original path. The panel does not close automatically -- the user must close it manually.
+
+If the file later reappears at the same path (e.g., the user recreates it), the panel does NOT automatically reconnect. Close and reopen the panel to pick up the new file.
+
+## Performance
+
+- Re-reads are dispatched to the main thread and run synchronously.
+- Large files (100KB+) may cause brief UI hitches during re-render. For extremely large markdown files, consider splitting into smaller documents.
+- The file watcher runs on a low-priority background queue and has negligible CPU impact.
+
+## Tips for Agents
+
+- **Write the full plan file first, then open it.** This avoids the panel showing a partially written file.
+- **Append-style updates work well.** Adding sections to the end of a file triggers a smooth re-render.
+- **Overwriting the entire file is fine.** The atomic replace handling ensures no data is lost.
+- **Don't delete and recreate rapidly.** If writing a new version, prefer overwriting in place or using atomic replacement.

--- a/claude/skills/cmux-settings/SKILL.md
+++ b/claude/skills/cmux-settings/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: cmux-settings
+description: "View and edit cmux settings in ~/.config/cmux/cmux.json. Use when the user wants to change cmux preferences (appearance, sidebar, notifications, automation, browser, shortcuts), set a value by JSON path, validate the file, open it in an editor, or look up which keys cmux recognizes. Triggers on '/cmux-settings', 'change cmux setting', 'set <something> in cmux', 'cmux config', 'cmux.json', or 'rebind a cmux shortcut'."
+---
+
+# cmux-settings
+
+cmux reads user settings from `~/.config/cmux/cmux.json` (JSONC). The app installs a file watcher; saving the file applies changes immediately, no restart needed. Legacy `~/.config/cmux/settings.json` is read only as a fallback for keys not present in `cmux.json`.
+
+Schema: `https://raw.githubusercontent.com/manaflow-ai/cmux/main/web/data/cmux.schema.json`. The authoritative path list lives in `Sources/CmuxSettingsJSONPathSupport.swift` in the cmux checkout, and the installed skill includes a generated copy in `references/all-keys.md`. Top-level sections are `app`, `terminal`, `notifications`, `sidebar`, `sidebarAppearance`, `workspaceColors`, `automation`, `browser`, and `shortcuts`. Non-settings sections (`actions`, `ui`, `commands`, `vault`, `rightSidebar`) coexist in the same file.
+
+## Helper script
+
+Use the bundled helper for every read/write. It strips JSONC comments, writes atomically, and validates keys against the schema.
+
+```bash
+# From a cmux checkout
+skills/cmux-settings/scripts/cmux-settings <subcommand>
+
+# From an installed Codex skill
+~/.codex/skills/cmux-settings/scripts/cmux-settings <subcommand>
+```
+
+For brevity in the rest of this doc, assume the script is on `$PATH` as `cmux-settings`. To make it so for a session from a checkout: `export PATH="$PWD/skills/cmux-settings/scripts:$PATH"`.
+
+Subcommands:
+
+| Command | What it does |
+|---|---|
+| `cmux-settings path` | Print the config path. |
+| `cmux-settings dump` | Print the raw file (preserves comments). |
+| `cmux-settings dump --no-comments` | Print the parsed JSON. |
+| `cmux-settings get <a.b.c>` | Print value at dotted JSON path. |
+| `cmux-settings set <a.b.c> <value>` | Set value. `<value>` is parsed as JSON (`true`, `42`, `"text"`, `[…]`, `{…}`); plain strings without quotes are stored as strings. |
+| `cmux-settings unset <a.b.c>` | Delete key, reverting to the in-app default. |
+| `cmux-settings list-supported` | List every settings JSON path the app recognizes. |
+| `cmux-settings validate` | Parse the file and flag any unknown settings keys. |
+| `cmux-settings open` | Open `cmux.json` in `$EDITOR`, VS Code, Cursor, or TextEdit. |
+
+`--file <path>` overrides the target file (useful for `--file ~/.config/cmux/settings.json` when the user keeps things in the legacy file).
+
+## Workflow
+
+1. Confirm the change. If the user named a setting in plain English (e.g. "make the sidebar tint match the terminal background"), look it up first.
+   ```bash
+   cmux-settings list-supported | rg -i 'sidebar.*terminal|terminal.*sidebar'
+   ```
+2. Set the value. JSON literals (`true`, `false`, numbers, arrays, objects) must be valid JSON. Plain words are stored as strings.
+   ```bash
+   cmux-settings set sidebarAppearance.matchTerminalBackground true
+   cmux-settings set app.appearance dark
+   cmux-settings set shortcuts.bindings.toggleSidebar cmd+b
+   cmux-settings set shortcuts.bindings.newTab '["ctrl+b","c"]'
+   cmux-settings set browser.hostsToOpenInEmbeddedBrowser '["localhost","*.internal.example"]'
+   ```
+3. Verify by reading back and validating.
+   ```bash
+   cmux-settings get sidebarAppearance.matchTerminalBackground
+   cmux-settings validate
+   ```
+4. Tell the user it auto-reloaded. No app restart. If they want to revert, run `cmux-settings unset <key>`.
+
+## Quick reference
+
+- Appearance: `app.appearance` = `"system" | "light" | "dark"`, `app.appIcon`, `app.menuBarOnly`, `app.minimalMode`.
+- Sidebar tint: `sidebarAppearance.matchTerminalBackground`, `sidebarAppearance.tintColor`, `sidebarAppearance.tintOpacity` (0..1).
+- Sidebar details: `sidebar.hideAllDetails`, `sidebar.showBranchDirectory`, `sidebar.showPullRequests`, `sidebar.showPorts`, `sidebar.showLog`.
+- Notifications: `notifications.dockBadge`, `notifications.sound` (enum incl. `"none"`, `"custom_file"`), `notifications.customSoundFilePath`, `notifications.hooks` (array).
+- Browser: `browser.defaultSearchEngine`, `browser.theme`, `browser.openTerminalLinksInCmuxBrowser`, `browser.hostsToOpenInEmbeddedBrowser`.
+- Automation: `automation.socketControlMode` (`off | cmuxOnly | automation | password | allowAll`), `automation.portBase`, `automation.portRange`.
+- Shortcuts: `shortcuts.bindings.<actionId>` = `"cmd+b"`, `["ctrl+b","c"]`, `null`, or `""` to unbind. See `references/shortcut-actions.md`.
+
+For the full list of settings, defaults, and descriptions, run `cmux-settings list-supported` or read [references/all-keys.md](references/all-keys.md).
+
+## Rules
+
+- Only edit `cmux.json`. Never edit `settings.json` unless the user explicitly asks; it is legacy and only read when the key is absent from `cmux.json`.
+- Never tell the user to restart cmux to apply a change. The file watcher reloads on save.
+- Always validate after a bulk edit: `cmux-settings validate`. Unknown keys mean the user pasted a key the app does not consume.
+- Do not blindly overwrite top-level sections (`actions`, `ui`, `commands`, `vault`, `rightSidebar`). They live in the same file and contain non-settings config the user has hand-tuned.
+- Shortcut action ids must match the schema enum. Look them up in [references/shortcut-actions.md](references/shortcut-actions.md) before binding.
+- Color values must be `#RRGGBB`. Opacities are `0..1`.
+- For settings the user expressed in app-level language (e.g. "Settings > Notifications > Dock badge"), translate to the matching JSON path first; the docs page at `web/app/[locale]/docs/configuration/page.tsx` mirrors the schema 1:1.

--- a/claude/skills/cmux-settings/agents/openai.yaml
+++ b/claude/skills/cmux-settings/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cmux Settings"
+  short_description: "Inspect, edit, validate, and reload cmux.json settings."
+  default_prompt: "Use this skill to change cmux settings safely: map user-facing preferences to cmux.json paths, edit with the bundled helper, validate recognized keys, and rely on cmux's live config reload."

--- a/claude/skills/cmux-settings/references/all-keys.md
+++ b/claude/skills/cmux-settings/references/all-keys.md
@@ -1,0 +1,140 @@
+# All settings keys
+
+Auto-generated from `web/data/cmux.schema.json`. For the rendered docs, see `https://cmux.com/docs/configuration`.
+
+## app
+
+General app preferences from Settings > App.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `app.language` | `"system"` or `"en"` or `"ar"` or `"bs"` or `"zh-Hans"` or `"zh-Hant"` or `"da"` or `"de"` or `"es"` or `"fr"` or `"it"` or `"ja"` or `"ko"` or `"nb"` or `"pl"` or `"pt-BR"` or `"ru"` or `"th"` or `"tr"` | `"system"` | Preferred app language. |
+| `app.appearance` | `"system"` or `"light"` or `"dark"` | `"system"` | App appearance mode. |
+| `app.appIcon` | `"automatic"` or `"light"` or `"dark"` | `"automatic"` | Dock and app switcher icon style. |
+| `app.menuBarOnly` | boolean | `false` | Hide the Dock icon and app switcher entry while keeping cmux available from the menu bar. |
+| `app.newWorkspacePlacement` | `"top"` or `"afterCurrent"` or `"end"` | `"afterCurrent"` | Where new workspaces are inserted in the sidebar. |
+| `app.workspaceInheritWorkingDirectory` | boolean | `true` | When true, new workspaces inherit the current workspace working directory. When false, new workspaces leave the working directory unset so Ghostty's working-directory setting can provide the default. |
+| `app.minimalMode` | boolean | `false` | Hide the workspace title bar and move controls into the sidebar. |
+| `app.keepWorkspaceOpenWhenClosingLastSurface` | boolean | `false` | When true, closing the last surface keeps the workspace open. |
+| `app.focusPaneOnFirstClick` | boolean | `true` | When cmux is inactive, the first click can activate and focus the clicked pane. |
+| `app.preferredEditor` | string | `""` | Custom editor command used when Cmd-click file previews are disabled or a file is unsupported. Leave empty to use the default. |
+| `app.openSupportedFilesInCmux` | boolean | `true` | When enabled, Cmd-clicking readable local files opens supported previews in cmux, including text, code, PDFs, images, audio, video, and Quick Look files. Preview headers include an Open With menu based on the user's default and compatible macOS apps for that file. |
+| `app.openMarkdownInCmuxViewer` | boolean | `true` | When enabled, Cmd-clicking .md/.markdown/.mkd/.mdx files opens the rendered cmux markdown viewer panel (with live reload) instead of the generic file preview. |
+| `app.reorderOnNotification` | boolean | `true` | Move workspaces with new notifications toward the top. |
+| `app.iMessageMode` | boolean | `false` | Move a workspace to the top and show the submitted message when sending an agent prompt. |
+| `app.sendAnonymousTelemetry` | boolean | `true` | Allow anonymous telemetry. |
+| `app.warnBeforeQuit` | boolean | `true` | Show a confirmation before quitting cmux. |
+| `app.warnBeforeClosingTab` | boolean | `true` | Show a confirmation before closing a tab. |
+| `app.renameSelectsExistingName` | boolean | `true` | Select the current name when opening rename flows. |
+| `app.commandPaletteSearchesAllSurfaces` | boolean | `false` | Search every surface in the command palette switcher instead of only the active workspace. |
+
+## terminal
+
+Terminal presentation settings from Settings > Terminal.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `terminal.showScrollBar` | boolean | `true` | Show the right-edge terminal scroll bar when scrollback is available. cmux automatically suppresses it for alternate-screen style TUI surfaces. |
+| `terminal.autoResumeAgentSessions` | boolean | `true` | Automatically run agent resume commands for restored terminal sessions when cmux reopens after quit. Set false to restore panes while keeping Claude Code, Codex, OpenCode, and other saved agent sessions idle until you resume them manually. |
+
+## notifications
+
+Notification behavior from Settings > Notifications.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `notifications.dockBadge` | boolean | `true` | Show the unread count in the Dock tile. |
+| `notifications.showInMenuBar` | boolean | `true` | Show the menu bar extra. |
+| `notifications.unreadPaneRing` | boolean | `true` | Highlight panes with unread notifications. |
+| `notifications.paneFlash` | boolean | `true` | Flash the focused pane when requested. |
+| `notifications.sound` | `"default"` or `"Basso"` or `"Blow"` or `"Bottle"` or `"Frog"` or `"Funk"` or `"Glass"` or `"Hero"` or `"Morse"` or `"Ping"` or `"Pop"` or `"Purr"` or `"Sosumi"` or `"Submarine"` or `"Tink"` or `"custom_file"` or `"none"` | `"default"` | Notification sound preset. |
+| `notifications.customSoundFilePath` | string | `""` | Local path to the custom notification sound file. |
+| `notifications.command` | string | `""` | Optional shell command to run alongside notification delivery. |
+| `notifications.hooksMode` | `"append"` or `"replace"` | `"append"` | Controls whether project-local notification hooks append to inherited hooks or replace them. |
+| `notifications.hooks` | array<object> | `[]` | Composable shell hooks that receive notification policy JSON on stdin and return updated policy JSON on stdout. |
+
+## sidebar
+
+Sidebar content and metadata visibility from Settings > Sidebar.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `sidebar.hideAllDetails` | boolean | `false` | Hide all per-workspace detail rows. |
+| `sidebar.showWorkspaceDescription` | boolean | `true` | Show custom workspace descriptions in the sidebar. |
+| `sidebar.branchLayout` | `"vertical"` or `"inline"` | `"vertical"` | Show git branch details stacked vertically or inline. |
+| `sidebar.showNotificationMessage` | boolean | `true` | Show the latest notification text in the sidebar. |
+| `sidebar.showBranchDirectory` | boolean | `true` | Show the workspace working directory. |
+| `sidebar.showPullRequests` | boolean | `true` | Show pull request metadata in the sidebar. |
+| `sidebar.makePullRequestsClickable` | boolean | `true` | Allow sidebar pull request metadata to open links when clicked. |
+| `sidebar.openPullRequestLinksInCmuxBrowser` | boolean | `true` | Open sidebar pull request links in the embedded cmux browser. |
+| `sidebar.openPortLinksInCmuxBrowser` | boolean | `true` | Open sidebar port links in the embedded cmux browser. |
+| `sidebar.showSSH` | boolean | `true` | Show SSH connection details. |
+| `sidebar.showPorts` | boolean | `true` | Show listening ports. |
+| `sidebar.showLog` | boolean | `true` | Show recent log snippets. |
+| `sidebar.showProgress` | boolean | `true` | Show progress indicators. |
+| `sidebar.showCustomMetadata` | boolean | `true` | Show custom metadata pills. |
+
+## workspaceColors
+
+Workspace tab and badge colors from Settings > Workspace Colors.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `workspaceColors.indicatorStyle` | `"leftRail"` or `"solidFill"` or `"rail"` or `"border"` or `"wash"` or `"lift"` or `"typography"` or `"washRail"` or `"blueWashColorRail"` | `"leftRail"` | Active workspace indicator style. Legacy aliases are accepted and normalized. |
+| `workspaceColors.selectionColor` | colorHexOrNull | `null` | Override the selected workspace background color. |
+| `workspaceColors.notificationBadgeColor` | colorHexOrNull | `null` | Override the unread notification badge color. |
+| `workspaceColors.colors` | object | `{"Red": "#C0392B", "Crimson": "#922B21", "Orange": "#A04000", "Amber": "#7D6608", "Olive": "#4A5C18", "Green": "#196F3D", "Teal": "#006B6B", "Aqua": "#0E6B8C", "Blue": "#1565C0", "Navy": "#1A5276", "Indigo": "#283593", "Purple": "#6A1B9A", "Magenta": "#AD1457", "Rose": "#880E4F", "Brown": "#7B3F00", "Charcoal": "#3E4B5E"}` | Full named workspace color palette. Include built-in entries you want to keep, remove keys to remove colors, and add more named entries to extend the picker. |
+| `workspaceColors.paletteOverrides` | object | `{}` | Legacy workspace color overrides for built-in palette names. Prefer workspaceColors.colors for new configs. |
+| `workspaceColors.customColors` | array<colorHex> | `[]` | Legacy list of custom workspace colors. Prefer workspaceColors.colors for new configs. |
+
+## sidebarAppearance
+
+Sidebar tint settings from Settings > Sidebar Appearance.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `sidebarAppearance.matchTerminalBackground` | boolean | `false` | Use the terminal background instead of the sidebar tint. |
+| `sidebarAppearance.tintColor` | colorHex | `"#000000"` | Base sidebar tint color used when light/dark overrides are not set. |
+| `sidebarAppearance.lightModeTintColor` | colorHexOrNull | `null` | Sidebar tint override for light appearance. |
+| `sidebarAppearance.darkModeTintColor` | colorHexOrNull | `null` | Sidebar tint override for dark appearance. |
+| `sidebarAppearance.tintOpacity` | number | `0.03` | Sidebar tint opacity from 0 to 1. Note: this only controls the sidebar tint, not terminal/window transparency. For terminal background transparency or blur, set `background-opacity` and `background-blur` in `~/.config/ghostty/config` and run `cmux reload-config`. |
+
+## automation
+
+Socket control and automation settings from Settings > Automation.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `automation.socketControlMode` | `"off"` or `"cmuxOnly"` or `"automation"` or `"password"` or `"allowAll"` or `"openAccess"` or `"fullOpenAccess"` or `"notifications"` or `"full"` | `"cmuxOnly"` | Socket control mode. Legacy aliases are accepted and normalized. |
+| `automation.socketPassword` | string or null | `""` | Password for password-mode socket access. Use null or an empty string to clear it. |
+| `automation.claudeCodeIntegration` | boolean | `true` | Enable cmux integration hooks for Claude Code. |
+| `automation.claudeBinaryPath` | string | `""` | Custom path to the claude binary. |
+| `automation.cursorIntegration` | boolean | `true` | Enable cmux integration hooks for Cursor. |
+| `automation.geminiIntegration` | boolean | `true` | Enable cmux integration hooks for Gemini. |
+| `automation.portBase` | integer | `9100` | Starting value for workspace CMUX_PORT assignments. |
+| `automation.portRange` | integer | `10` | Number of ports reserved per workspace. |
+
+## browser
+
+Embedded browser settings from Settings > Browser.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `browser.defaultSearchEngine` | `"google"` or `"duckduckgo"` or `"bing"` or `"kagi"` or `"startpage"` | `"google"` | Default search engine for non-URL queries. |
+| `browser.showSearchSuggestions` | boolean | `true` | Show omnibar search suggestions. |
+| `browser.theme` | `"system"` or `"light"` or `"dark"` | `"system"` | Embedded browser theme. |
+| `browser.openTerminalLinksInCmuxBrowser` | boolean | `true` | Open clicked terminal links in the embedded browser. |
+| `browser.interceptTerminalOpenCommandInCmuxBrowser` | boolean | `true` | Intercept terminal open http(s) commands and route them through the embedded browser. |
+| `browser.hostsToOpenInEmbeddedBrowser` | array<string> | `[]` | Allowlist of hosts that should stay inside the embedded browser. |
+| `browser.urlsToAlwaysOpenExternally` | array<string> | `[]` | Rules that always open matching URLs in the system browser. |
+| `browser.insecureHttpHostsAllowedInEmbeddedBrowser` | array<string> | `["localhost", "*.localhost", "127.0.0.1", "::1", "0.0.0.0", "*.localtest.me"]` | HTTP hosts allowed in the embedded browser without a warning prompt. |
+| `browser.showImportHintOnBlankTabs` | boolean | `true` | Show the browser import hint on blank tabs. |
+| `browser.reactGrabVersion` | string | `"0.1.29"` | Pinned react-grab version for the browser toolbar helper. |
+
+## shortcuts
+
+Keyboard shortcut settings from Settings > Keyboard Shortcuts.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `shortcuts.bindings` | object | `{}` | Shortcut overrides keyed by cmux action id. Use a string for a single shortcut, an array for a chord, null, an empty string, none, clear, unbound, or disabled to unbind. |

--- a/claude/skills/cmux-settings/references/shortcut-actions.md
+++ b/claude/skills/cmux-settings/references/shortcut-actions.md
@@ -1,0 +1,111 @@
+# Keyboard shortcut action ids
+
+Auto-generated from `web/data/cmux.schema.json` (`shortcuts.bindings.propertyNames.enum`).
+
+Values for `shortcuts.bindings.<action>`:
+
+- A string like `"cmd+b"` for a single shortcut.
+- A two-element array like `["ctrl+b","c"]` for a chord.
+- `null` or an empty string (`""`, `"none"`, `"clear"`, `"unbound"`, `"disabled"`) to unbind.
+
+## App
+
+- `shortcuts.bindings.openSettings`
+- `shortcuts.bindings.reloadConfiguration`
+- `shortcuts.bindings.showHideAllWindows`
+- `shortcuts.bindings.globalSearch`
+- `shortcuts.bindings.newWindow`
+- `shortcuts.bindings.closeWindow`
+- `shortcuts.bindings.toggleFullScreen`
+- `shortcuts.bindings.quit`
+- `shortcuts.bindings.openFolder`
+- `shortcuts.bindings.sendFeedback`
+
+## Tabs
+
+- `shortcuts.bindings.newTab`
+- `shortcuts.bindings.reopenPreviousSession`
+- `shortcuts.bindings.renameTab`
+- `shortcuts.bindings.closeTab`
+- `shortcuts.bindings.closeOtherTabsInPane`
+
+## Workspace
+
+- `shortcuts.bindings.goToWorkspace`
+- `shortcuts.bindings.selectWorkspaceByNumber`
+- `shortcuts.bindings.renameWorkspace`
+- `shortcuts.bindings.editWorkspaceDescription`
+- `shortcuts.bindings.closeWorkspace`
+
+## Panes and surfaces
+
+- `shortcuts.bindings.nextSurface`
+- `shortcuts.bindings.prevSurface`
+- `shortcuts.bindings.selectSurfaceByNumber`
+- `shortcuts.bindings.newSurface`
+- `shortcuts.bindings.toggleTerminalCopyMode`
+- `shortcuts.bindings.focusLeft`
+- `shortcuts.bindings.focusRight`
+- `shortcuts.bindings.focusUp`
+- `shortcuts.bindings.focusDown`
+- `shortcuts.bindings.splitRight`
+- `shortcuts.bindings.splitDown`
+- `shortcuts.bindings.toggleSplitZoom`
+- `shortcuts.bindings.equalizeSplits`
+
+## Command palette
+
+- `shortcuts.bindings.commandPalette`
+- `shortcuts.bindings.commandPaletteNext`
+- `shortcuts.bindings.commandPalettePrevious`
+
+## Notifications
+
+- `shortcuts.bindings.showNotifications`
+- `shortcuts.bindings.jumpToUnread`
+- `shortcuts.bindings.toggleUnread`
+- `shortcuts.bindings.markOldestUnreadAndJumpNext`
+- `shortcuts.bindings.triggerFlash`
+
+## Right sidebar
+
+- `shortcuts.bindings.toggleSidebar`
+- `shortcuts.bindings.focusRightSidebar`
+- `shortcuts.bindings.switchRightSidebarToFiles`
+- `shortcuts.bindings.switchRightSidebarToFind`
+- `shortcuts.bindings.switchRightSidebarToSessions`
+- `shortcuts.bindings.switchRightSidebarToFeed`
+- `shortcuts.bindings.switchRightSidebarToDock`
+- `shortcuts.bindings.nextSidebarTab`
+- `shortcuts.bindings.prevSidebarTab`
+
+## Browser
+
+- `shortcuts.bindings.reopenClosedBrowserPanel`
+- `shortcuts.bindings.splitBrowserRight`
+- `shortcuts.bindings.splitBrowserDown`
+- `shortcuts.bindings.openBrowser`
+- `shortcuts.bindings.focusBrowserAddressBar`
+- `shortcuts.bindings.browserBack`
+- `shortcuts.bindings.browserForward`
+- `shortcuts.bindings.browserReload`
+- `shortcuts.bindings.browserZoomIn`
+- `shortcuts.bindings.browserZoomOut`
+- `shortcuts.bindings.browserZoomReset`
+- `shortcuts.bindings.toggleBrowserDeveloperTools`
+- `shortcuts.bindings.showBrowserJavaScriptConsole`
+
+## Find
+
+- `shortcuts.bindings.find`
+- `shortcuts.bindings.findInDirectory`
+- `shortcuts.bindings.findNext`
+- `shortcuts.bindings.findPrevious`
+- `shortcuts.bindings.hideFind`
+- `shortcuts.bindings.useSelectionForFind`
+
+## Files and React Grab
+
+- `shortcuts.bindings.toggleFileExplorer`
+- `shortcuts.bindings.saveFilePreview`
+- `shortcuts.bindings.toggleReactGrab`

--- a/claude/skills/cmux-settings/scripts/cmux-settings
+++ b/claude/skills/cmux-settings/scripts/cmux-settings
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+"""Inspect and edit ~/.config/cmux/cmux.json.
+
+cmux watches the file and auto-reloads on save, so writes take effect
+immediately. The file is JSONC (JSON with // and /* */ comments); this
+script writes comment-free formatting (2-space indent, trailing newline)
+and only writes when the parsed value actually changes.
+
+Usage:
+  cmux-settings path                    print the config path
+  cmux-settings dump [--no-comments]    print current settings (raw or stripped)
+  cmux-settings get <dotted.path>       print value at path (JSON)
+  cmux-settings set <dotted.path> <v>   set value (v parsed as JSON, falls back to string)
+  cmux-settings unset <dotted.path>     remove value at path
+  cmux-settings list-supported          print every settings path the schema recognizes
+  cmux-settings validate                check JSON parses and all set keys are recognized
+  cmux-settings open                    open the file in $EDITOR (or VS Code, then TextEdit)
+
+Examples:
+  cmux-settings set app.appearance dark
+  cmux-settings set notifications.dockBadge false
+  cmux-settings set shortcuts.bindings.toggleSidebar '"cmd+b"'
+  cmux-settings set shortcuts.bindings.newTab '["ctrl+b","c"]'
+  cmux-settings unset app.appearance
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+DEFAULT_PATH = Path.home() / ".config" / "cmux" / "cmux.json"
+SCHEMA_URL = (
+    "https://raw.githubusercontent.com/manaflow-ai/cmux/main/web/data/cmux.schema.json"
+)
+
+
+def strip_jsonc(text: str) -> str:
+    """Remove // line comments and /* block comments outside strings."""
+    out: list[str] = []
+    i, n = 0, len(text)
+    in_string = False
+    string_quote = ""
+    while i < n:
+        ch = text[i]
+        if in_string:
+            out.append(ch)
+            if ch == "\\" and i + 1 < n:
+                out.append(text[i + 1])
+                i += 2
+                continue
+            if ch == string_quote:
+                in_string = False
+            i += 1
+            continue
+        if ch in ('"', "'"):
+            in_string = True
+            string_quote = ch
+            out.append(ch)
+            i += 1
+            continue
+        if ch == "/" and i + 1 < n and text[i + 1] == "/":
+            j = text.find("\n", i + 2)
+            i = n if j == -1 else j
+            continue
+        if ch == "/" and i + 1 < n and text[i + 1] == "*":
+            j = text.find("*/", i + 2)
+            i = n if j == -1 else j + 2
+            continue
+        out.append(ch)
+        i += 1
+    # Drop trailing commas before ] or } (also legal in JSONC).
+    return strip_trailing_commas_outside_strings("".join(out))
+
+
+def strip_trailing_commas_outside_strings(text: str) -> str:
+    """Remove JSONC trailing commas without touching string contents."""
+    out: list[str] = []
+    i, n = 0, len(text)
+    in_string = False
+    string_quote = ""
+    while i < n:
+        ch = text[i]
+        if in_string:
+            out.append(ch)
+            if ch == "\\" and i + 1 < n:
+                out.append(text[i + 1])
+                i += 2
+                continue
+            if ch == string_quote:
+                in_string = False
+            i += 1
+            continue
+        if ch in ('"', "'"):
+            in_string = True
+            string_quote = ch
+            out.append(ch)
+            i += 1
+            continue
+        if ch == ",":
+            j = i + 1
+            while j < n and text[j].isspace():
+                j += 1
+            if j < n and text[j] in "}]":
+                i += 1
+                continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def load_settings(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"$schema": SCHEMA_URL, "schemaVersion": 1}
+    raw = path.read_text()
+    try:
+        return json.loads(strip_jsonc(raw))
+    except json.JSONDecodeError as e:
+        raise SystemExit(f"error: {path} is not valid JSONC: {e}")
+
+
+def atomic_write(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    encoded = json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+    with tempfile.NamedTemporaryFile(
+        mode="w", encoding="utf-8", dir=path.parent, delete=False, suffix=".tmp"
+    ) as tmp:
+        tmp.write(encoded)
+        tmp_path = Path(tmp.name)
+    os.replace(tmp_path, path)
+
+
+def split_path(dotted: str) -> list[str]:
+    if not dotted:
+        raise SystemExit("error: empty key path")
+    parts = dotted.split(".")
+    if any(part == "" for part in parts):
+        raise SystemExit("error: empty key path segment")
+    return parts
+
+
+def get_at(data: Any, parts: list[str]) -> Any:
+    cur = data
+    for p in parts:
+        if not isinstance(cur, dict) or p not in cur:
+            raise SystemExit(f"error: path not present: {'.'.join(parts)}")
+        cur = cur[p]
+    return cur
+
+
+def set_at(data: dict[str, Any], parts: list[str], value: Any) -> bool:
+    cur = data
+    for p in parts[:-1]:
+        if p not in cur:
+            cur[p] = {}
+        elif not isinstance(cur[p], dict):
+            raise SystemExit(
+                f"error: intermediate key '{p}' is not an object "
+                f"(got {type(cur[p]).__name__}); cannot set nested path"
+            )
+        cur = cur[p]
+    leaf = parts[-1]
+    changed = (leaf not in cur) or cur[leaf] != value
+    cur[leaf] = value
+    return changed
+
+
+def unset_at(data: dict[str, Any], parts: list[str]) -> bool:
+    trail: list[tuple[dict[str, Any], str]] = []
+    cur: Any = data
+    for p in parts[:-1]:
+        if not isinstance(cur, dict) or p not in cur:
+            return False
+        trail.append((cur, p))
+        cur = cur[p]
+    if not isinstance(cur, dict) or parts[-1] not in cur:
+        return False
+    del cur[parts[-1]]
+    # Drop now-empty ancestor objects so the file stays tidy.
+    for parent, key in reversed(trail):
+        if isinstance(parent[key], dict) and not parent[key]:
+            del parent[key]
+        else:
+            break
+    return True
+
+
+def parse_value(raw: str) -> Any:
+    """Try JSON first; if it fails, fall back to a plain string."""
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
+
+
+def flatten(prefix: str, value: Any) -> list[str]:
+    if isinstance(value, dict):
+        out: list[str] = []
+        for k, v in value.items():
+            child = f"{prefix}.{k}" if prefix else k
+            out.extend(flatten(child, v))
+        return out
+    return [prefix]
+
+
+def supported_paths_from_source(source: Path) -> list[str]:
+    text = source.read_text()
+    known_sections = (
+        "app.",
+        "terminal.",
+        "notifications.",
+        "sidebar.",
+        "workspaceColors.",
+        "sidebarAppearance.",
+        "automation.",
+        "browser.",
+        "shortcuts.",
+    )
+    candidates = re.findall(r'"([a-zA-Z]+\.[a-zA-Z0-9_.]+)"', text)
+    return sorted({p for p in candidates if p.startswith(known_sections)})
+
+
+def supported_paths_from_reference(skill_root: Path | None) -> list[str]:
+    if skill_root is None:
+        return []
+    reference = skill_root / "references" / "all-keys.md"
+    if not reference.exists():
+        return []
+    text = reference.read_text()
+    return sorted(set(re.findall(r"^\| `([^`]+)` \|", text, re.MULTILINE)))
+
+
+def find_source_file() -> Path | None:
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        direct = parent / "Sources" / "CmuxSettingsJSONPathSupport.swift"
+        if direct.exists():
+            return direct
+        hq_checkout = parent / "repo" / "Sources" / "CmuxSettingsJSONPathSupport.swift"
+        if hq_checkout.exists():
+            return hq_checkout
+    return None
+
+
+def find_skill_root() -> Path | None:
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if parent.name == "cmux-settings" and (parent / "SKILL.md").exists():
+            return parent
+        if (parent / "references" / "all-keys.md").exists():
+            return parent
+    return None
+
+
+def supported_paths() -> list[str]:
+    source = find_source_file()
+    if source is not None:
+        return supported_paths_from_source(source)
+    return supported_paths_from_reference(find_skill_root())
+
+
+def cmd_path(args: argparse.Namespace) -> int:
+    print(args.file)
+    return 0
+
+
+def cmd_dump(args: argparse.Namespace) -> int:
+    path = Path(args.file)
+    if args.no_comments:
+        data = load_settings(path)
+        print(json.dumps(data, indent=2, ensure_ascii=False))
+    else:
+        if path.exists():
+            sys.stdout.write(path.read_text())
+        else:
+            print(f"# {path} does not exist", file=sys.stderr)
+            return 1
+    return 0
+
+
+def cmd_get(args: argparse.Namespace) -> int:
+    data = load_settings(Path(args.file))
+    value = get_at(data, split_path(args.key))
+    print(json.dumps(value, indent=2, ensure_ascii=False))
+    return 0
+
+
+def cmd_set(args: argparse.Namespace) -> int:
+    path = Path(args.file)
+    data = load_settings(path)
+    parts = split_path(args.key)
+    value = parse_value(args.value)
+    changed = set_at(data, parts, value)
+    if not changed:
+        print(f"unchanged: {args.key} = {json.dumps(value)}")
+        return 0
+    atomic_write(path, data)
+    print(f"set: {args.key} = {json.dumps(value)}")
+    return 0
+
+
+def cmd_unset(args: argparse.Namespace) -> int:
+    path = Path(args.file)
+    data = load_settings(path)
+    if not unset_at(data, split_path(args.key)):
+        print(f"unchanged: {args.key} (not present)")
+        return 0
+    atomic_write(path, data)
+    print(f"unset: {args.key}")
+    return 0
+
+
+def cmd_list_supported(args: argparse.Namespace) -> int:
+    paths = supported_paths()
+    if not paths:
+        print(
+            "error: could not load the supported-paths list; "
+            "run from a cmux checkout or reinstall the cmux-settings skill",
+            file=sys.stderr,
+        )
+        return 1
+    for p in paths:
+        print(p)
+    return 0
+
+
+def cmd_validate(args: argparse.Namespace) -> int:
+    path = Path(args.file)
+    data = load_settings(path)
+    supported = set(supported_paths())
+    if not supported:
+        print(
+            "warn: could not load schema path list; only checked JSON parses",
+            file=sys.stderr,
+        )
+        print(f"ok: {path} parses")
+        return 0
+    unknown: list[str] = []
+    # Keep this in sync with top-level structural keys in web/data/cmux.schema.json.
+    structural = {
+        "$schema",
+        "schemaVersion",
+        "actions",
+        "ui",
+        "commands",
+        "vault",
+        "newWorkspaceCommand",
+        "surfaceTabBarButtons",
+        "rightSidebar",
+    }
+    for top, value in data.items():
+        if top in structural:
+            continue
+        if not isinstance(value, dict):
+            unknown.append(top)
+            continue
+        for full in flatten(top, value):
+            if full in supported:
+                continue
+            if any(full.startswith(s + ".") for s in supported):
+                continue
+            unknown.append(full)
+    if unknown:
+        print("unknown settings keys:")
+        for u in unknown:
+            print(f"  {u}")
+        return 1
+    print(f"ok: {path} parses and all settings keys are recognized")
+    return 0
+
+
+def cmd_open(args: argparse.Namespace) -> int:
+    path = Path(args.file)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not path.exists():
+        atomic_write(path, {"$schema": SCHEMA_URL, "schemaVersion": 1})
+    editor = os.environ.get("EDITOR") or os.environ.get("VISUAL")
+    if editor:
+        try:
+            editor_args = shlex.split(editor)
+        except ValueError as e:
+            print(f"error: invalid editor command: {e}", file=sys.stderr)
+            return 1
+        if not editor_args:
+            print("error: editor command is empty", file=sys.stderr)
+            return 1
+        try:
+            return subprocess.call([*editor_args, str(path)])
+        except FileNotFoundError:
+            print(f"error: editor not found: {editor_args[0]}", file=sys.stderr)
+            return 1
+    for app in (["code", "--wait"], ["cursor", "--wait"], ["open", "-e"], ["xdg-open"]):
+        if shutil.which(app[0]):
+            try:
+                return subprocess.call([*app, str(path)])
+            except FileNotFoundError:
+                continue
+    print(
+        "error: no suitable editor found; set $EDITOR or install code, cursor, open, or xdg-open",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--file",
+        default=str(DEFAULT_PATH),
+        help=f"settings file path (default: {DEFAULT_PATH})",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("path").set_defaults(func=cmd_path)
+
+    p_dump = sub.add_parser("dump")
+    p_dump.add_argument("--no-comments", action="store_true")
+    p_dump.set_defaults(func=cmd_dump)
+
+    p_get = sub.add_parser("get")
+    p_get.add_argument("key")
+    p_get.set_defaults(func=cmd_get)
+
+    p_set = sub.add_parser("set")
+    p_set.add_argument("key")
+    p_set.add_argument("value")
+    p_set.set_defaults(func=cmd_set)
+
+    p_unset = sub.add_parser("unset")
+    p_unset.add_argument("key")
+    p_unset.set_defaults(func=cmd_unset)
+
+    sub.add_parser("list-supported").set_defaults(func=cmd_list_supported)
+    sub.add_parser("validate").set_defaults(func=cmd_validate)
+    sub.add_parser("open").set_defaults(func=cmd_open)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/claude/skills/cmux-workspace/SKILL.md
+++ b/claude/skills/cmux-workspace/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: cmux-workspace
+description: "Work inside the current cmux workspace and terminal. Use for cmux workspace, current workspace, caller surface, panes, surfaces, socket targeting, and non-interfering cmux automation."
+---
+
+# cmux Workspace
+
+Use this skill when a task should be scoped to the cmux workspace that invoked the agent. A workspace is the sidebar tab-like unit in cmux. It contains split panes, and each pane contains one or more surfaces. A surface is the terminal or browser session the user interacts with.
+
+## Default Rule
+
+Scope actions to the current caller workspace unless the user explicitly asks for another workspace, another window, or global state.
+
+Do not assume the visually focused cmux workspace is the right target. An agent can be running in one workspace while the user is looking at another. Prefer the caller environment first:
+
+```bash
+printf 'workspace=%s\nsurface=%s\nsocket=%s\n' \
+  "${CMUX_WORKSPACE_ID:-}" \
+  "${CMUX_SURFACE_ID:-}" \
+  "${CMUX_SOCKET_PATH:-}"
+cmux identify --json
+```
+
+Use `CMUX_WORKSPACE_ID` as the default workspace anchor and `CMUX_SURFACE_ID` as the default caller terminal/surface anchor. If those are missing, use `cmux identify --json` and be explicit that you are using the currently focused cmux context.
+
+## Non-Disruptive Automation
+
+The user may be visually focused on a different workspace, window, or app while an agent works in the caller workspace. Treat layout and focus as separate concerns. Never call focus-changing verbs speculatively.
+
+Never call these without an explicit user ask:
+
+- `select-workspace` switches the visible sidebar tab.
+- `focus-pane` / `focus-panel` yanks pane or surface focus.
+- `tab-action` with focus-changing actions.
+
+These are user-affecting actions, like clicks. The rule applies even inside the caller's own workspace, since the user may be looking elsewhere.
+
+Build layout additively, in one shot. Prefer commands that create a new pane already populated with the right surface:
+
+```bash
+# pane and content in one call, no follow-up needed
+cmux new-pane --workspace "${CMUX_WORKSPACE_ID}" --type browser --direction right --url "http://127.0.0.1:8765"
+cmux new-pane --workspace "${CMUX_WORKSPACE_ID}" --type terminal --direction down
+```
+
+Avoid create-then-move-then-focus chains. If a layout command rejects a valid `surface:` or `pane:` ref, do not work around it by focusing. Report the bug to the user and stop.
+
+Pass `--focus false` whenever the verb supports it. `move-surface --focus false` preserves the user's current attention. Other commands may grow the same flag over time (https://github.com/manaflow-ai/cmux/issues/1418, https://github.com/manaflow-ai/cmux/issues/2820).
+
+## Right-Side Helper Pane
+
+When opening auxiliary output for the current task (preview apps, TUIs, logs, one-off shells, browser checks), keep the workspace organized by reusing a helper pane to the right of the caller terminal.
+
+First inspect the caller context and panes:
+
+```bash
+cmux identify --json
+cmux list-panes --workspace "${CMUX_WORKSPACE_ID:-}" --json
+cmux list-pane-surfaces --workspace "${CMUX_WORKSPACE_ID:-}" --json
+```
+
+Use this policy:
+
+- If the caller workspace already has a non-caller helper pane, add a new surface to that pane instead of creating another pane:
+  ```bash
+  cmux new-surface --workspace "${CMUX_WORKSPACE_ID:-}" --pane pane:<helper> --type terminal --focus false
+  ```
+- If there is no helper pane, create exactly one right-side pane:
+  ```bash
+  cmux new-pane --workspace "${CMUX_WORKSPACE_ID:-}" --type terminal --direction right --focus false
+  ```
+- If there are multiple obvious stale helper panes from this same automation and the user asked to tidy or reuse, keep one right helper pane and clean up the duplicates. Do not close panes you cannot confidently identify as stale helper output.
+- Send commands to the new or reused helper surface by explicit surface ref. Do not focus it unless the user asks.
+
+This means repeated "open it" requests should normally create tabs inside the existing right helper pane, not more splits.
+
+## Hierarchy
+
+- Window: a macOS cmux window.
+- Workspace: a sidebar entry. The UI may call it a tab, but CLI/socket APIs call it a workspace.
+- Pane: a split region inside a workspace.
+- Surface: a tab inside a pane. Surfaces can be terminals or browser panels.
+- Panel: internal content type inside a surface. Prefer CLI surface commands instead of panel internals.
+
+## Inspect Current Context
+
+```bash
+cmux identify --json
+cmux current-workspace --json
+cmux list-workspaces --json
+cmux list-panes --workspace "${CMUX_WORKSPACE_ID:-}" --json
+cmux list-pane-surfaces --workspace "${CMUX_WORKSPACE_ID:-}" --json
+cmux list-panels --workspace "${CMUX_WORKSPACE_ID:-}" --json
+```
+
+Use `--id-format both` when logs or handoffs need stable UUIDs plus human refs:
+
+```bash
+cmux --json --id-format both identify
+```
+
+## Workspace-Scoped Actions
+
+Prefer explicit workspace flags even when env vars are set. It makes automation auditable and avoids affecting a focused workspace in another window.
+
+```bash
+# create a new workspace when the user asks for a new task area
+cmux new-workspace --name "debug auth" --cwd "$PWD"
+
+# rename / close (only when explicitly requested)
+cmux rename-workspace --workspace "${CMUX_WORKSPACE_ID:-}" -- "build fix"
+cmux close-workspace --workspace workspace:4
+cmux close-surface --workspace "${CMUX_WORKSPACE_ID:-}" --surface surface:3
+
+# additive layout (safe, no focus side effects beyond the command's own defaults)
+cmux new-pane --workspace "${CMUX_WORKSPACE_ID:-}" --type terminal --direction right
+cmux new-surface --workspace "${CMUX_WORKSPACE_ID:-}" --type terminal
+
+# focus-changing (USER-AFFECTING, only on explicit ask, see Non-Disruptive Automation above)
+cmux select-workspace --workspace workspace:2
+cmux focus-pane --workspace "${CMUX_WORKSPACE_ID:-}" --pane pane:2
+cmux focus-panel --workspace "${CMUX_WORKSPACE_ID:-}" --panel surface:3
+```
+
+## Caller Terminal
+
+The current terminal is the surface that invoked the agent. Treat it as the safest anchor for relative operations.
+
+```bash
+# send to the focused terminal in the caller workspace
+cmux send "npm test\n"
+
+# send to the exact caller surface
+cmux send --surface "${CMUX_SURFACE_ID:-}" "git status\n"
+cmux send-key --surface "${CMUX_SURFACE_ID:-}" enter
+```
+
+Do not send keystrokes, close surfaces, or change focus in other workspaces unless the user asked for that target.
+
+## Moving Surfaces
+
+Reorder a surface within its pane:
+
+```bash
+cmux move-surface --surface "${CMUX_SURFACE_ID}" --before surface:3
+cmux move-surface --surface "${CMUX_SURFACE_ID}" --after surface:3
+cmux move-surface --surface "${CMUX_SURFACE_ID}" --index 0
+```
+
+Move a surface to another existing pane. Pass `--focus false` to keep the user's current attention put:
+
+```bash
+cmux move-surface --surface surface:240 --pane pane:172 --focus false
+```
+
+Split a surface off into a new pane:
+
+```bash
+cmux drag-surface-to-split --surface surface:240 down
+```
+
+Known papercut: `drag-surface-to-split` currently routes through V1 and resolves the workspace via UI focus, so it can fail with `ERROR: Surface not found` when the caller's workspace is not the visually focused one. Tracked at https://github.com/manaflow-ai/cmux/issues/1901, related to https://github.com/manaflow-ai/cmux/issues/3189. Until that lands, prefer building the layout additively (see Non-Disruptive Automation above) over create-then-split.
+
+Do not call `focus-pane` or `focus-panel` to recover from a failed move. Report the failure and stop.
+
+## Sidebar State
+
+Status, progress, and logs should usually be attached to the current workspace so the sidebar reflects this task.
+
+```bash
+cmux set-status build "running" --workspace "${CMUX_WORKSPACE_ID:-}" --color "#ff9500"
+cmux set-progress 0.4 --label "Building" --workspace "${CMUX_WORKSPACE_ID:-}"
+cmux log --workspace "${CMUX_WORKSPACE_ID:-}" --level info -- "Started build"
+cmux sidebar-state --workspace "${CMUX_WORKSPACE_ID:-}" --json
+cmux clear-status build --workspace "${CMUX_WORKSPACE_ID:-}"
+cmux clear-progress --workspace "${CMUX_WORKSPACE_ID:-}"
+```
+
+## Contributor Reloads
+
+For cmux app/runtime changes in a cmux source checkout, use tagged reloads from the active worktree. A tagged reload creates an isolated app name, bundle ID, debug socket, and DerivedData path.
+
+```bash
+./scripts/reload.sh --tag <short-tag>
+```
+
+Never build or launch untagged `cmux DEV`. If tests or tools need a socket, use the tag-specific socket:
+
+```bash
+CMUX_SOCKET_PATH=/tmp/cmux-debug-<short-tag>.sock cmux identify --json
+```
+
+## Socket and Access
+
+Use the socket path provided by cmux before falling back to defaults:
+
+```bash
+SOCK="${CMUX_SOCKET_PATH:-/tmp/cmux.sock}"
+```
+
+Socket access can be off, restricted to cmux-spawned processes, or allow all local processes. If a command cannot connect, inspect capabilities before changing settings:
+
+```bash
+cmux capabilities --json
+cmux ping
+```
+
+## References
+
+- [references/commands.md](references/commands.md) enumerates workspace, pane, surface, notification, and utility commands.
+- [../cmux-browser/SKILL.md](../cmux-browser/SKILL.md) covers browser surfaces with the same current-workspace rule.
+
+## Rules
+
+- Work in the current caller workspace by default.
+- Use `CMUX_WORKSPACE_ID`, `CMUX_SURFACE_ID`, and `CMUX_SOCKET_PATH` before focused-window fallbacks.
+- Prefer explicit `--workspace` and `--surface` flags for mutating actions.
+- Never call `focus-pane`, `focus-panel`, `select-workspace`, or focus-changing `tab-action` verbs unless the user explicitly asked. The user may be visually on a different workspace, window, or app.
+- Pass `--focus false` on `move-surface` and any creation verb that supports it.
+- For auxiliary output, reuse the right-side helper pane; create one only if it does not exist.
+- Build layout additively with `new-pane --type ... --url ...` rather than create-then-move-then-focus chains.
+- If a CLI command rejects a valid surface or pane ref, report it to the user. Do not work around by focusing.
+- Do not close, focus, move, or send input to another workspace unless the user names that target.
+- Use short refs for chat and command examples. Use UUIDs only for logs, persistence, or debugging.
+- For app/runtime changes in a cmux source checkout, reload with `./scripts/reload.sh --tag <tag>` from the worktree before dogfood handoff.

--- a/claude/skills/cmux-workspace/agents/openai.yaml
+++ b/claude/skills/cmux-workspace/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cmux Workspace"
+  short_description: "Scope cmux automation to the current workspace, caller terminal, panes, and surfaces."
+  default_prompt: "Use this skill to identify the current cmux caller workspace and surface, then keep workspace, pane, surface, browser, sidebar, and socket actions scoped to that context unless the user explicitly names another target."

--- a/claude/skills/cmux-workspace/references/commands.md
+++ b/claude/skills/cmux-workspace/references/commands.md
@@ -1,0 +1,110 @@
+# cmux Workspace Command Reference
+
+Use these commands from a cmux terminal. Most commands infer the caller workspace from `CMUX_WORKSPACE_ID`, but explicit flags are safer for automation.
+
+## Context
+
+```bash
+cmux identify --json
+cmux current-workspace --json
+cmux capabilities --json
+cmux ping
+```
+
+## Windows and Workspaces
+
+```bash
+cmux list-windows
+cmux current-window
+cmux new-window
+cmux focus-window --window window:2
+cmux close-window --window window:2
+
+cmux list-workspaces
+cmux list-workspaces --json
+cmux new-workspace --name "task" --cwd "$PWD"
+cmux new-workspace --command "npm run dev"
+cmux new-workspace --layout '{"root":{"type":"terminal"}}'
+cmux current-workspace
+cmux select-workspace --workspace workspace:2
+cmux rename-workspace --workspace workspace:2 -- "new name"
+cmux close-workspace --workspace workspace:2
+cmux reorder-workspace --workspace workspace:4 --before workspace:2
+cmux move-workspace-to-window --workspace workspace:4 --window window:1
+```
+
+## Panes and Surfaces
+
+```bash
+cmux list-panes --workspace "$CMUX_WORKSPACE_ID"
+cmux list-pane-surfaces --workspace "$CMUX_WORKSPACE_ID" --pane pane:1
+cmux list-panels --workspace "$CMUX_WORKSPACE_ID"
+cmux tree --workspace "$CMUX_WORKSPACE_ID"
+
+cmux new-split right --workspace "$CMUX_WORKSPACE_ID"
+cmux new-split down --workspace "$CMUX_WORKSPACE_ID" --surface "$CMUX_SURFACE_ID"
+cmux new-pane --workspace "$CMUX_WORKSPACE_ID" --type terminal --direction right
+cmux new-pane --workspace "$CMUX_WORKSPACE_ID" --type browser --url http://localhost:3000
+cmux new-surface --workspace "$CMUX_WORKSPACE_ID" --type terminal --pane pane:1
+cmux new-surface --workspace "$CMUX_WORKSPACE_ID" --type browser --pane pane:1 --url http://localhost:3000
+
+cmux focus-pane --workspace "$CMUX_WORKSPACE_ID" --pane pane:2
+cmux focus-panel --workspace "$CMUX_WORKSPACE_ID" --panel surface:3
+cmux close-surface --workspace "$CMUX_WORKSPACE_ID" --surface surface:3
+cmux move-surface --surface surface:7 --pane pane:2 --focus true
+cmux reorder-surface --surface surface:7 --before surface:3
+cmux move-tab-to-new-workspace --surface surface:7 --title "browser"
+```
+
+## Input
+
+```bash
+cmux send "echo hello\n"
+cmux send-key enter
+cmux send --surface "$CMUX_SURFACE_ID" "git status\n"
+cmux send-key --surface "$CMUX_SURFACE_ID" enter
+cmux read-screen --surface "$CMUX_SURFACE_ID"
+```
+
+## Sidebar Metadata
+
+```bash
+cmux set-status build "running" --workspace "$CMUX_WORKSPACE_ID" --icon hammer --color "#ff9500"
+cmux clear-status build --workspace "$CMUX_WORKSPACE_ID"
+cmux list-status --workspace "$CMUX_WORKSPACE_ID"
+cmux set-progress 0.5 --workspace "$CMUX_WORKSPACE_ID" --label "Building"
+cmux clear-progress --workspace "$CMUX_WORKSPACE_ID"
+cmux log --workspace "$CMUX_WORKSPACE_ID" --level info -- "Build started"
+cmux list-log --workspace "$CMUX_WORKSPACE_ID" --limit 20
+cmux clear-log --workspace "$CMUX_WORKSPACE_ID"
+cmux sidebar-state --workspace "$CMUX_WORKSPACE_ID" --json
+```
+
+## Notifications and Attention
+
+```bash
+cmux notify --title "Done" --body "Task complete"
+cmux list-notifications --json
+cmux clear-notifications
+cmux trigger-flash --workspace "$CMUX_WORKSPACE_ID" --surface "$CMUX_SURFACE_ID"
+cmux surface-health --workspace "$CMUX_WORKSPACE_ID" --json
+```
+
+## Config and Docs
+
+```bash
+cmux docs api
+cmux docs browser
+cmux docs settings
+cmux settings path
+cmux settings cmux-json
+cmux settings shortcuts
+cmux reload-config
+```
+
+## Tagged Reloads
+
+```bash
+./scripts/reload.sh --tag <short-tag>
+CMUX_SOCKET_PATH=/tmp/cmux-debug-<short-tag>.sock cmux identify --json
+```

--- a/claude/skills/cmux/SKILL.md
+++ b/claude/skills/cmux/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: cmux
+description: End-user control of cmux topology and routing (windows, workspaces, panes/surfaces, focus, moves, reorder, identify, trigger flash). Use when automation needs deterministic placement and navigation in a multi-pane cmux layout.
+---
+
+# cmux Core Control
+
+Use this skill to control non-browser cmux topology and routing.
+
+## Core Concepts
+
+- Window: top-level macOS cmux window.
+- Workspace: tab-like group within a window.
+- Pane: split container in a workspace.
+- Surface: a tab within a pane (terminal or browser panel).
+
+## Fast Start
+
+```bash
+# identify current caller context
+cmux identify --json
+
+# list topology
+cmux list-windows
+cmux list-workspaces
+cmux list-panes
+cmux list-pane-surfaces --pane pane:1
+
+# create/focus/move
+cmux new-workspace
+cmux new-split right --panel pane:1
+cmux move-surface --surface surface:7 --pane pane:2 --focus true
+cmux split-off --surface surface:7 right
+cmux reorder-surface --surface surface:7 --before surface:3
+
+# attention cue
+cmux trigger-flash --surface surface:7
+```
+
+## Settings and Docs
+
+Use `cmux docs settings` before changing cmux-owned settings. It prints the docs URL, schema URL, raw GitHub resources, cmux.json paths, and reload command.
+
+```bash
+cmux docs settings
+cmux settings path
+```
+
+cmux-owned settings live in `~/.config/cmux/cmux.json`. Legacy `~/.config/cmux/settings.json` and `~/Library/Application Support/com.cmuxterm.app/settings.json` files are read only as fallback for missing keys. Before editing, copy any existing `cmux.json` file to a timestamped `.bak` next to it so the user can revert. Edit the user file, then reload:
+
+```bash
+cmux reload-config
+```
+
+`cmux reload-config` reloads BOTH `cmux.json` and Ghostty config (`~/.config/ghostty/config`) and refreshes terminals in place. No app restart needed.
+
+Use cmux settings for app behavior, sidebar, notifications, browser behavior, automation, workspace colors, and cmux-owned shortcuts. Terminal rendering settings such as font, cursor style, theme, scrollback, background transparency (`background-opacity`), and blur (`background-blur`) belong in Ghostty config at `~/.config/ghostty/config`.
+
+Open the UI when useful:
+
+```bash
+cmux settings
+cmux settings cmux-json
+cmux settings shortcuts
+```
+
+## Handle Model
+
+- Default output uses short refs: `window:N`, `workspace:N`, `pane:N`, `surface:N`.
+- UUIDs are still accepted as inputs.
+- Request UUID output only when needed: `--id-format uuids|both`.
+
+## Deep-Dive References
+
+| Reference | When to Use |
+|-----------|-------------|
+| [references/handles-and-identify.md](references/handles-and-identify.md) | Handle syntax, self-identify, caller targeting |
+| [references/windows-workspaces.md](references/windows-workspaces.md) | Window/workspace lifecycle and reorder/move |
+| [references/panes-surfaces.md](references/panes-surfaces.md) | Splits, surfaces, move/reorder, focus routing |
+| [references/trigger-flash-and-health.md](references/trigger-flash-and-health.md) | Flash cue and surface health checks |
+| [../cmux-workspace/SKILL.md](../cmux-workspace/SKILL.md) | Current caller workspace rules and non-disruptive automation |
+| [../cmux-settings/SKILL.md](../cmux-settings/SKILL.md) | Safe cmux.json settings edits and validation |
+| [../cmux-browser/SKILL.md](../cmux-browser/SKILL.md) | Browser automation on surface-backed webviews |
+| [../cmux-markdown/SKILL.md](../cmux-markdown/SKILL.md) | Markdown viewer panel with live file watching |

--- a/claude/skills/cmux/agents/openai.yaml
+++ b/claude/skills/cmux/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cmux Core"
+  short_description: "Control windows/workspaces/panes/surfaces and routing with cmux CLI."
+  default_prompt: "Use this skill to inspect and manipulate cmux topology: identify context, target handles, create/focus/move/reorder windows/workspaces/panes/surfaces, and use trigger-flash for visual confirmation."

--- a/claude/skills/cmux/references/handles-and-identify.md
+++ b/claude/skills/cmux/references/handles-and-identify.md
@@ -1,0 +1,35 @@
+# Handles and Identify
+
+Use `identify` and short handles for deterministic automation targeting.
+
+## Handle Inputs
+
+Most v2-backed commands accept:
+- UUID
+- short ref (`window:N`, `workspace:N`, `pane:N`, `surface:N`)
+- index (where legacy/index-based commands still allow it)
+
+## Self Identify
+
+```bash
+cmux identify --json
+```
+
+Returns current focused topology plus optional caller resolution.
+
+## Caller Override
+
+```bash
+cmux identify --workspace workspace:2
+cmux identify --workspace workspace:2 --surface surface:8
+```
+
+Useful for agents that need to route relative actions from a known caller anchor.
+
+## Output Shaping
+
+```bash
+cmux --json identify                 # refs-first output
+cmux --json --id-format both identify
+cmux --json --id-format uuids identify
+```

--- a/claude/skills/cmux/references/panes-surfaces.md
+++ b/claude/skills/cmux/references/panes-surfaces.md
@@ -1,0 +1,37 @@
+# Panes and Surfaces
+
+Split layout, surface creation, focus, move, and reorder.
+
+## Inspect
+
+```bash
+cmux list-panes
+cmux list-pane-surfaces --pane pane:1
+```
+
+## Create Splits/Surfaces
+
+```bash
+cmux new-split right --panel pane:1
+cmux new-surface --type terminal --pane pane:1
+cmux new-surface --type browser --pane pane:1 --url https://example.com
+```
+
+## Focus and Close
+
+```bash
+cmux focus-pane --pane pane:2
+cmux focus-panel --panel surface:7
+cmux close-surface --surface surface:7
+```
+
+## Move/Reorder Surfaces
+
+```bash
+cmux move-surface --surface surface:7 --pane pane:2 --focus true
+cmux move-surface --surface surface:7 --workspace workspace:2 --window window:1 --after surface:4
+cmux split-off --surface surface:7 right
+cmux reorder-surface --surface surface:7 --before surface:3
+```
+
+Surface identity is stable across move/reorder/split-off operations. Layout commands are focus-neutral by default; pass `--focus true` only when you want the moved or created surface selected.

--- a/claude/skills/cmux/references/trigger-flash-and-health.md
+++ b/claude/skills/cmux/references/trigger-flash-and-health.md
@@ -1,0 +1,23 @@
+# Trigger Flash and Surface Health
+
+Operational checks useful in automation loops.
+
+## Trigger Flash
+
+Flash a surface or workspace to provide visual confirmation in UI:
+
+```bash
+cmux trigger-flash --surface surface:7
+cmux trigger-flash --workspace workspace:2
+```
+
+## Surface Health
+
+Use health output to detect hidden/detached/non-windowed surfaces:
+
+```bash
+cmux surface-health
+cmux surface-health --workspace workspace:2
+```
+
+Use this before routing focused input if UI state may be stale.

--- a/claude/skills/cmux/references/windows-workspaces.md
+++ b/claude/skills/cmux/references/windows-workspaces.md
@@ -1,0 +1,31 @@
+# Windows and Workspaces
+
+Window/workspace lifecycle and ordering operations.
+
+## Inspect
+
+```bash
+cmux list-windows
+cmux current-window
+cmux list-workspaces
+cmux current-workspace
+```
+
+## Create/Focus/Close
+
+```bash
+cmux new-window
+cmux focus-window --window window:2
+cmux close-window --window window:2
+
+cmux new-workspace
+cmux select-workspace --workspace workspace:4
+cmux close-workspace --workspace workspace:4
+```
+
+## Reorder and Move
+
+```bash
+cmux reorder-workspace --workspace workspace:4 --before workspace:2
+cmux move-workspace-to-window --workspace workspace:4 --window window:1
+```

--- a/claude/skills/plannotator-compound/SKILL.md
+++ b/claude/skills/plannotator-compound/SKILL.md
@@ -1,0 +1,575 @@
+---
+name: plannotator-compound
+disable-model-invocation: true
+description: >
+  Analyze a user's Plannotator plan archive to extract denial patterns, feedback
+  taxonomy, evolution over time, and actionable prompt improvements — then produce
+  a polished HTML dashboard report. Falls back to Claude Code ExitPlanMode denial
+  reasons when Plannotator data is unavailable.
+---
+
+# Compound Planning Analysis
+
+You are conducting a comprehensive research analysis of a user's Plannotator plan
+archive. The goal: extract patterns from their denied plans, reduce
+them into actionable insights, and produce an elegant HTML dashboard report.
+
+This is a multi-phase process. Each phase must complete fully before the next begins.
+Research integrity is paramount — every file must be read, no skipping.
+
+## Source Selection
+
+Before starting the analysis, determine which data source is available.
+
+1. **Plannotator mode (first-class)** — Determine the Plannotator data directory:
+   use `$PLANNOTATOR_DATA_DIR` if set, otherwise `~/.plannotator`. Check the
+   `plans/` subdirectory there. If it exists and contains `*-denied.md` files,
+   use this mode. The entire workflow below is written for Plannotator data.
+
+2. **Claude Code fallback mode** — If the Plannotator archive is absent or
+   contains no denied plans, check `~/.claude/projects/`. If present, read
+   [references/claude-code-fallback.md](references/claude-code-fallback.md)
+   before continuing. That reference explains how to use the bundled parser at
+   [scripts/extract_exit_plan_mode_outcomes.py](scripts/extract_exit_plan_mode_outcomes.py)
+   to extract denial reasons from Claude Code JSONL transcripts. Every phase
+   below has a short note explaining what changes in fallback mode — the
+   reference file has the details.
+
+3. **Neither available** — Ask the user for their Plannotator plans directory or
+   Claude Code projects directory. Do not guess.
+
+## Phase 0: Locate Plans & Check for Previous Reports
+
+Use the mode chosen in Source Selection above.
+
+**Plannotator mode:** Verify the plans directory contains `*-denied.md` files. If
+none exist, fall back to Claude Code mode before stopping.
+
+**Claude Code fallback mode:** Run the bundled parser per the fallback reference to
+build the denial-reason dataset. Create `/tmp/compound-planning/` if needed.
+
+In either mode, proceed to Previous Report Detection below.
+
+### Previous Report Detection
+
+After locating the plans directory, check for existing reports:
+
+```
+ls ${PLANNOTATOR_DATA_DIR:-~/.plannotator}/plans/compound-planning-report*.html
+```
+
+Reports follow a versioned naming scheme:
+- First report: `compound-planning-report.html`
+- Subsequent reports: `compound-planning-report-v2.html`, `compound-planning-report-v3.html`, etc.
+
+If one or more reports exist, determine the **latest** one (highest version number).
+Get its filesystem modification date using `stat` (macOS: `stat -f %Sm -t %Y-%m-%d`,
+Linux: `stat -c %y | cut -d' ' -f1`). This is the **cutoff date**.
+
+Present the user with a choice:
+
+> "I found a previous report (`compound-planning-report-v{N}.html`) last updated
+> on {CUTOFF_DATE}. I can either:
+>
+> 1. **Incremental** — Only analyze files dated after {CUTOFF_DATE}, saving tokens
+>    and building on previous findings
+> 2. **Full** — Re-analyze the entire archive from scratch
+>
+> Which would you prefer?"
+
+Wait for the user's response before proceeding.
+
+**If incremental:** Filter all subsequent phases to only process files with dates
+after the cutoff date. The new report version will note in its header narrative that
+it covers the period from {CUTOFF_DATE} to present, and reference the previous
+report for earlier findings. The inventory (Phase 1) should still count ALL files
+for overall stats, but clearly separate "new since last report" counts.
+
+**If full:** Proceed normally with all files, but still use the next version number
+for the output filename.
+
+**If no previous report exists:** Proceed normally. The output filename will be
+`compound-planning-report.html` (no version suffix for the first report).
+
+## Phase 1: Inventory
+
+Count and report the dataset. **Always count ALL files** for overall stats,
+regardless of whether this is an incremental or full run:
+
+```
+- *-approved.md files (count)
+- *-denied.md files (count)
+- Date range (earliest to latest date found in filenames)
+- Total days spanned
+- Revision rate: denied / (approved + denied) — this is the "X% of plans
+  revised before coding" stat used in dashboard section 1
+```
+
+**Note:** Ignore `*.annotations.md` files entirely. Denied files already contain
+the full plan text plus all reviewer feedback appended after a `---` separator.
+Annotation files are redundant subsets of this content — reading both would
+double-count feedback.
+
+**If incremental mode:** After the total counts, separately report the counts for
+files dated after the cutoff date only:
+
+```
+New since {CUTOFF_DATE}:
+- *-denied.md files: X (of Y total)
+- New date range: {CUTOFF_DATE} to {LATEST_DATE}
+- New days spanned: N
+```
+
+If fewer than 3 new denied files exist since the cutoff, warn the user:
+> "Only {N} new denied plans since the last report. The incremental analysis may
+> be thin. Would you like to proceed or switch to a full analysis?"
+
+Also run `wc -l` across all `*-approved.md` files to get average lines per
+approved plan. This tells the user whether their plans are staying lightweight
+or bloating over time. You do not need to read approved plan contents — just
+their line counts. If possible, break this down by time period (e.g., monthly)
+to show whether plan size changed.
+
+Dates appear in filenames in YYYY-MM-DD format, sometimes as a prefix
+(2026-01-07-name-approved.md) and sometimes embedded (name-2026-03-15-approved.md).
+Extract dates from all filenames.
+
+Tell the user what you found and that you're beginning the extraction.
+
+**Claude Code fallback mode:** The Plannotator inventory fields above do not apply.
+Follow the inventory instructions in
+[references/claude-code-fallback.md](references/claude-code-fallback.md) instead —
+report the denial-reason dataset assembled by the parser.
+
+## Phase 2: Map — Parallel Extraction
+
+This is the most time-intensive phase. You must read EVERY `*-denied.md` file
+**in scope**. Do not skip files. Do not summarize early.
+
+**In scope** means: all denied files if running a full analysis, or only denied
+files dated after the cutoff date if running incrementally. In incremental mode,
+only process files whose embedded YYYY-MM-DD date is strictly after the cutoff.
+
+**Claude Code fallback mode:** The parser output is the clean source dataset. Read
+the fallback reference for the extraction prompt and batching strategy specific to
+JSON part files. Do not go back to raw `.jsonl` logs unless the parser fails or the
+user asks for audit-level verification.
+
+**Important:** Only read `*-denied.md` files. Do NOT read approved plans,
+annotation files, or diff files. Each denied file contains the full plan text
+followed by a `---` separator and the reviewer's feedback — everything needed
+for analysis is in one file.
+
+### Batching Strategy
+
+All extraction agents should use `model: "haiku"` — they're doing straightforward
+file reading and structured extraction, not reasoning. Haiku is faster and cheaper
+for this work.
+
+The approach depends on dataset size:
+
+**Tiny datasets (≤ 10 total files):** Read all files directly in the main agent —
+no need for sub-agents. Just read them sequentially and proceed to Phase 3.
+
+**Small datasets (11-30 files):** Launch 2-3 parallel Haiku agents, splitting
+files roughly evenly.
+
+**Medium datasets (31-80 files):** Launch 4-6 parallel Haiku agents (~10-15 files
+each). Split by file type and/or time period.
+
+**Large datasets (80+ files):** Launch as many parallel Haiku agents as needed to
+keep each batch around 10-15 files. Split by the natural time boundaries in the
+data (months, quarters, or whatever groupings produce balanced batches). If one
+time period dominates (e.g., the most recent month has 3x the files), split that
+period into multiple batches.
+
+Launch all extraction agents in parallel using the Agent tool with
+`run_in_background: true` and `model: "haiku"`.
+
+### Output Files
+
+Each extraction agent must write its results to a clean output file rather than
+relying on the agent task output (which contains interleaved JSONL framework
+logs that are difficult to parse). Instruct each agent to write to:
+
+```
+/tmp/compound-planning/extraction-{batch-name}.md
+```
+
+Create the `/tmp/compound-planning/` directory before launching agents. The
+reduce agent in Phase 3 will read these clean files directly.
+
+### Extraction Prompt
+
+Each agent receives this instruction (adapt the time period, file list, and
+output path):
+
+```
+You are extracting structured data from denied plan files for a pattern analysis.
+
+Directory: [PLANS DIRECTORY]
+Files to read: [LIST OF SPECIFIC *-denied.md FILES]
+Output: Write your complete results to [OUTPUT FILE PATH]
+
+Each denied file contains two parts separated by a --- line:
+1. The plan text (above the ---)
+2. The reviewer's feedback and annotations (below the ---)
+
+Read EVERY file in your list. For EACH file, extract:
+- The plan name/topic (from the plan text above the ---)
+- The denial reason or feedback given (from below the --- — capture the actual
+  words used)
+- What was specifically asked to change
+- The type of feedback (let the content determine the category — don't force-fit
+  into predefined types. Common types include things like: scope concerns,
+  approach disagreements, missing information, process requirements, quality
+  concerns, UX/design issues, naming disputes, clarification requests,
+  testing/procedural denials — but the user's actual patterns may differ)
+- Any specific phrases or recurring language from the reviewer
+- Individual annotations if present (numbered feedback items with quoted text
+  and reviewer comments)
+- The date (extracted from the filename)
+
+Do NOT skip any files. One entry per file.
+
+Format each entry as:
+**[filename]**
+- Date: ...
+- Topic: ...
+- Denial reason: ...
+- Feedback type: ...
+- Specific asks: ...
+- Notable phrases: ...
+- Annotations: [count, with brief summary of each]
+---
+
+After processing all files, write the complete results to [OUTPUT FILE PATH].
+State the total file count at the end of the file.
+```
+
+### While Agents Run
+
+Track completion. As each agent finishes, note the count of files it processed.
+Verify the total matches the inventory from Phase 1. If any agent's count is
+short, flag it and consider re-launching for the missing files.
+
+If an agent times out (possible with large batches — a batch of 128 files can
+take 8+ minutes), re-launch it for just the unprocessed files. Check the output
+file to see how far it got before timing out.
+
+## Phase 3: Reduce — Pattern Analysis
+
+Once ALL extraction agents have completed (or all files have been read for tiny
+datasets), proceed with the reduction. Reduction agents should use `model: "sonnet"`
+— this phase requires real analytical reasoning, not just file reading.
+
+### Reduction Strategy
+
+The approach depends on how many extraction files were produced:
+
+**Standard (≤ 20 extraction files):** Launch a single Sonnet agent to read all
+extraction files and produce the full analysis. This covers most datasets.
+
+**Large (21+ extraction files):** Use a two-stage reduce:
+
+1. **Stage 1 — Partial reduces:** Split the extraction files into groups of 4-6.
+   Launch parallel Sonnet agents, each reading one group and producing a partial
+   analysis with the same sections listed below. Each writes to
+   `/tmp/compound-planning/partial-reduce-{N}.md`.
+
+2. **Stage 2 — Final reduce:** A single Sonnet agent reads all partial reduce
+   files and synthesizes them into the final comprehensive analysis. This agent
+   merges taxonomies, combines counts, deduplicates patterns, and reconciles any
+   conflicting categorizations across partials.
+
+**Claude Code fallback mode:** The reduction phase is the same. The only upstream
+difference is that extraction files were derived from normalized denial-reason JSON
+instead of Plannotator markdown files.
+
+### Reduction Prompt
+
+Give each reduction agent this prompt (adapt file paths for single vs multi-stage):
+
+```
+You are a data scientist conducting the reduction phase of a map-reduce analysis
+across a user's denied plan archive.
+
+Read ALL extraction files at [FILE PATHS]
+
+These files contain structured extractions from every denied plan file. Each
+extraction includes the plan topic, denial feedback, annotations, and reviewer
+language. Your job: aggregate everything, find patterns, cluster into a taxonomy,
+and produce a comprehensive analysis.
+
+Be exhaustive. Use real counts. Quote real phrases from the data. This is
+research — no hand-waving, no fabrication.
+
+Write your complete results to [OUTPUT FILE PATH].
+
+Produce the following sections:
+[... sections listed below ...]
+```
+
+The reduction agent's job is to let the data speak. Do not impose a predetermined
+framework — discover what's actually there. The analysis must produce:
+
+### 1. Denial Reason Taxonomy
+Categorize every denial into a finite set of types that emerge from the data. Count
+occurrences. Show percentages. Include real example quotes for each type. Aim for
+8-15 categories — enough to be specific, few enough to be scannable. Let the user's
+actual feedback determine what the categories are.
+
+### 2. Top Feedback Patterns (ranked by frequency)
+The 5-10 most recurring patterns. For each: what the reviewer consistently asks for,
+3+ example quotes from different files, and whether the pattern changed over time.
+
+### 3. Recurring Phrases
+Exact phrases the reviewer uses repeatedly, with counts and what they signal. These
+are the reviewer's vocabulary — their shorthand for what they care about.
+
+### 4. What the Reviewer Values (implicit preferences)
+Derived from patterns — what does this specific person care about most? Quality?
+Speed? Narrative? Architecture? Process? Simplicity? Rank by evidence strength.
+This section should feel like a personality profile of the reviewer's standards.
+
+### 5. What Agents Consistently Get Wrong
+The flip side — what recurring mistakes trigger denials? What should agents stop
+doing for this reviewer?
+
+### 6. Structural Requests
+What plan structure does the reviewer consistently demand? Required sections,
+ordering, format preferences, level of detail expected.
+
+### 7. Evolution Over Time
+How feedback patterns changed across the time span. Group by whatever natural time
+boundaries exist in the data (weeks for short spans, months for longer ones). Did
+expectations mature? Did new patterns emerge? What shifted? If the dataset spans
+less than a month, note that evolution analysis is limited but still look for any
+progression from early to late files.
+
+### 8. Actionable Prompt Instructions
+The most important output. Based on all patterns: specific numbered instructions
+that could be embedded in a planning prompt to prevent the most common denial
+reasons. Write these as actual directives an agent could follow. Be specific to
+this user's patterns — generic advice like "write good plans" is worthless. Each
+instruction should trace back to a real, frequent denial pattern.
+
+After writing the instructions, calculate what percentage of denials they would
+address (count how many denials fall into categories covered by the instructions
+vs total denials). Report this percentage — it will be different for every user.
+
+## Phase 4: Generate the HTML Dashboard
+
+Build a single, self-contained HTML file as the final deliverable. Save it to
+the user's plans directory with a versioned filename:
+
+- First ever report: `compound-planning-report.html`
+- Second report: `compound-planning-report-v2.html`
+- Third report: `compound-planning-report-v3.html`
+- And so on.
+
+The version number was determined in Phase 0 based on existing reports found.
+
+**If this is an incremental report**, the header should indicate the analysis
+period (e.g., "March 15 – March 31, 2026") and include a subtitle noting
+"Incremental analysis — see v{N-1} for earlier findings." The narrative in
+section 1 should frame findings as what's new or changed since the last report,
+not as a complete picture. Overall stats in the header (file counts, revision
+rate) should still reflect the full archive for context.
+
+Read the template at `assets/report-template.html` for the **design language
+only**. The template contains example data from a previous analysis — ignore all
+data values, quotes, and percentages in the template. Use only its visual design:
+colors, typography, spacing, component styles, and layout patterns.
+
+### Design Language (from template)
+
+- **Palette:** Light mode, warm off-white (#FDFCFB), text in slate scale, amber
+  for highlights/accents, emerald for positive, rose for negative, indigo for
+  action elements
+- **Typography:** Playfair Display (serif, for narrative headings), Inter (sans,
+  for body/data), JetBrains Mono (mono, for code/phrases) — Google Fonts CDN
+- **Layout:** Single-column, max-width 1024px, generous vertical whitespace (128px
+  between major sections), editorial/narrative-first aesthetic
+- **Tone:** Calm, reflective, authoritative. Like a personal retrospective journal,
+  not a monitoring dashboard.
+
+### Page Frame (header + footer)
+
+Before the 7 sections, the page has:
+
+- **Header:** Report title on the left (Playfair Display, ~36px), project name +
+  date range below it in light meta text. On the right: file counts in mono
+  (e.g., "223 denials · 71 days"). Separated from content by
+  a bottom border. Generous bottom padding before section 1.
+
+- **Footer:** After section 7. Top border, centered italic Playfair Display tagline
+  summarizing the corpus (e.g., "Analysis of X denied plans from the Plannotator
+  archive.").
+
+### Dashboard Section Order (7 sections)
+
+The report follows this exact section order. Each section builds on the previous
+one — the flow moves from "what happened" through "why" to "what to do about it":
+
+1. **The story in the data** — An editorial narrative paragraph (Playfair Display
+   serif, ~26px) that tells the headline finding in prose. Not bullet points — a
+   real paragraph that reads like the opening of an article. Alongside it, a KPI
+   sidebar with 3 key metrics (the top denial percentage, the overall revision
+   rate, and the number of distinct denial categories found). Use an amber inline
+   highlight on the most striking number in the narrative.
+
+2. **Why plans get denied** — The taxonomy as a ranked list. Each row: rank number
+   (mono), category label, a thin 4px progress bar (top item in amber-500, rest
+   in slate-300), percentage (mono), and for the top entries, a real italic quote
+   from the data below the label. Show the top 10 categories or however many the
+   data supports (minimum 5).
+
+3. **How expectations evolved** — One card per natural time period. Each card has:
+   the period name in serif, a theme phrase in colored uppercase (different color
+   per period to show progression), a description paragraph, and a stat line at
+   the bottom (e.g., "X denials · Y narrative requests"). If the data spans less
+   than 3 distinct periods, use 2 cards or even a single card with internal
+   progression noted.
+
+4. **What works vs what doesn't** — Two side-by-side cards. Left: green-tinted
+   (emerald-50/50 bg, emerald-100 border) with traits of plans that succeed for
+   this reviewer. Right: red-tinted (rose-50/50 bg, rose-100 border) with what
+   agents keep getting wrong. Both derived from the reduction analysis. Bulleted
+   with small colored dots. 5-8 items per card.
+
+5. **The actionable output** — The diagnostic payoff. Opens with a Playfair
+   Display narrative sentence stating how many prompt instructions were derived
+   and what estimated percentage of denials they address (use the real calculated
+   percentage from Phase 3, not a generic number). Then the top 3 most impactful
+   improvements as numbered items, each with an amber number, bold title, and
+   one-line description. This section bridges the analysis and the full prompt
+   that follows.
+
+6. **Your most-used phrases** — Grid of chips (2-col mobile, 3-col desktop). Each
+   chip: monospace quoted phrase on the left, frequency count on the right. White
+   bg, slate-200 border, rounded-12px. Show 9-12 of the most recurring phrases
+   found. These should be the reviewer's actual words — their verbal fingerprint.
+
+7. **The corrective prompt** — Dark panel (slate-900 bg, white text, rounded-3xl,
+   shadow-xl). Opens with a Playfair intro sentence about the instructions. Then
+   a dark code block (slate-800/80 bg, amber-200 monospace text) containing the
+   full numbered prompt instructions from Phase 3. Include a copy-to-clipboard
+   button that works (JS included). Below the code block: a gradient glow card
+   (indigo-to-purple blurred halo behind a white card) with a closing message
+   that these instructions are personal — derived from the user's own feedback,
+   their own language, their own standards.
+
+### Adaptation Rules
+
+- If the user has < 3 months of data, reduce the evolution section to fewer cards
+- If most denied files lack feedback below the `---` (bare denials with no
+  annotations), note this in the narrative — the analysis will be thinner
+- **Claude Code fallback mode:** Explicitly label the report source as Claude Code
+  `ExitPlanMode` denial reasons. Do not fabricate Plannotator-only fields such as
+  annotation counts or approved-plan line counts. See the fallback reference for
+  KPI substitutes and footer/provenance guidance.
+- If fewer than 5 denial categories emerge, combine the taxonomy and patterns
+  sections into one
+- If the dataset is very small (< 20 files), the narrative should acknowledge the
+  limited sample size and frame findings as preliminary
+- The number of prompt instructions will vary per user — could be 8 or 20. Don't
+  force exactly 17. Let the data determine the count.
+- The top 3 actionable items in section 5 must be the 3 that cover the largest
+  share of denials, not the 3 that sound most impressive
+
+### Key Rules
+
+1. Every number must come from the real analysis — no fabricated data
+2. Every quote must be a real quote from a real file
+3. The taxonomy percentages must be calculated from real counts
+4. The prompt instructions must trace back to actual denial patterns
+5. The copy button on the prompt block must work (include the JS)
+
+After generating, open the file in the user's browser.
+
+## Phase 5: Summary
+
+Tell the user:
+- How many denied files were analyzed
+- If incremental: how many were new since the last report
+- The top 3 denial patterns found
+- The estimated percentage of denials the prompt instructions would address
+- The single most impactful prompt improvement
+- Where the report was saved (including version number)
+- If incremental: remind the user that earlier findings are in the previous report
+
+**Claude Code fallback mode:** Adapt the summary per the fallback reference —
+report human denial reasons analyzed and total `ExitPlanMode` attempts scanned
+instead of Plannotator file counts.
+
+## Phase 6: Improvement Hook
+
+After presenting the summary, ask the user if they want to enable an **improvement
+hook** — this takes the corrective prompt instructions from section 7 of the report
+and writes them to a file that Plannotator's `EnterPlanMode` hook can inject into
+every future planning session automatically.
+
+> "Would you like to enable the improvement hook? This will save the corrective
+> prompt instructions to a file that gets automatically injected into all future
+> planning sessions — so Claude sees your feedback patterns before writing any plan."
+
+**If yes:**
+
+The hook file lives at:
+
+```
+${PLANNOTATOR_DATA_DIR:-~/.plannotator}/hooks/compound/enterplanmode-improve-hook.txt
+```
+
+Create the `hooks/compound/` directory inside the data directory if it doesn't exist.
+
+The file contents should be the corrective prompt instructions from Phase 3 —
+the same numbered list that appears in section 7 of the HTML report. Write them
+as plain text, one instruction per line, prefixed with their number. No HTML, no
+markdown fences, no preamble — just the instructions themselves. The hook system
+will inject this file's contents as-is into the planning context.
+
+**If the file already exists:**
+
+Read the existing file and present the user with a choice:
+
+> "An improvement hook already exists from a previous analysis. I can:
+>
+> 1. **Replace** — Overwrite with the new instructions (the old ones are gone)
+> 2. **Merge** — Combine both, deduplicating overlapping instructions and
+>    keeping the best version of each
+> 3. **Keep existing** — Leave the current hook as-is, skip this step
+>
+> Which would you prefer?"
+
+- **Replace:** Overwrite the file with the new instructions.
+- **Merge:** Read the existing instructions, compare with the new ones, and
+  produce a merged set. Remove duplicates (same intent even if worded differently).
+  When two instructions cover the same pattern, keep the more specific or
+  actionable version. Re-number the final list sequentially. Write the merged
+  result to the file. Show the user what changed (added N new, removed N
+  redundant, kept N existing).
+- **Keep existing:** Do nothing, move on.
+
+**If no:** Skip this phase entirely.
+
+## Important Notes
+
+- **Data source priority:** Plannotator is the first-class path. Claude Code log
+  analysis is the secondary path for users without Plannotator archives.
+- **Research integrity:** Every file must be read. The value of this analysis comes
+  from completeness. Sampling or skipping undermines the findings.
+- **Real data only:** Never fabricate quotes, percentages, or patterns. If the data
+  doesn't show a clear pattern, say so honestly rather than inventing one.
+- **Let the data lead:** The taxonomy, patterns, and instructions should emerge from
+  what's actually in the files. Different users will have completely different
+  denial patterns. A user building mobile apps will have different feedback than
+  one building APIs. Don't assume what the patterns will be.
+- **Agent parallelization:** For large datasets, maximize parallel agents to reduce
+  wall-clock time. The bottleneck is the largest batch — split it.
+- **Structured extraction format:** Ask extraction agents to return structured text
+  with consistent delimiters so the reduce agent can parse reliably.
+- **The report is the artifact:** The HTML dashboard is what the user keeps. It
+  should be beautiful, honest, and useful. Every section should feel like it was
+  written about them specifically, because it was.

--- a/claude/skills/plannotator-compound/assets/report-template.html
+++ b/claude/skills/plannotator-compound/assets/report-template.html
@@ -1,0 +1,795 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Compound Planning — What 370 Files Reveal</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;1,400&family=Inter:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+  :root {
+    --bg: #FDFCFB;
+    --slate-900: #0f172a;
+    --slate-800: #1e293b;
+    --slate-700: #334155;
+    --slate-600: #475569;
+    --slate-500: #64748b;
+    --slate-400: #94a3b8;
+    --slate-300: #cbd5e1;
+    --slate-200: #e2e8f0;
+    --slate-100: #f1f5f9;
+    --slate-50: #f8fafc;
+    --amber-500: #f59e0b;
+    --amber-600: #d97706;
+    --amber-700: #b45309;
+    --amber-50: #fffbeb;
+    --emerald-500: #10b981;
+    --emerald-600: #059669;
+    --emerald-400: #34d399;
+    --emerald-900: #064e3b;
+    --emerald-800: #065f46;
+    --emerald-100: #d1fae5;
+    --emerald-50: #ecfdf5;
+    --rose-500: #f43f5e;
+    --rose-600: #e11d48;
+    --rose-400: #fb7185;
+    --rose-900: #881337;
+    --rose-800: #9f1239;
+    --rose-100: #ffe4e6;
+    --rose-50: #fff1f2;
+    --indigo-500: #6366f1;
+    --indigo-600: #4f46e5;
+    --purple-600: #9333ea;
+  }
+
+  body {
+    font-family: 'Inter', ui-sans-serif, system-ui, sans-serif;
+    background: var(--bg);
+    color: var(--slate-800);
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .container {
+    max-width: 1024px;
+    margin: 0 auto;
+    padding: 48px 24px 64px;
+  }
+  @media (min-width: 768px) { .container { padding: 96px 24px 80px; } }
+
+  /* Typography */
+  .font-serif { font-family: 'Playfair Display', ui-serif, Georgia, serif; }
+  .font-mono { font-family: 'JetBrains Mono', ui-monospace, monospace; }
+
+  /* Header */
+  header {
+    border-bottom: 1px solid var(--slate-200);
+    padding-bottom: 40px;
+    margin-bottom: 96px;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    flex-wrap: wrap;
+    gap: 16px;
+  }
+  header h1 {
+    font-family: 'Playfair Display', serif;
+    font-size: 36px;
+    font-weight: 400;
+    color: var(--slate-900);
+    line-height: 1.2;
+  }
+  header .meta {
+    font-size: 15px;
+    font-weight: 300;
+    color: var(--slate-500);
+    letter-spacing: 0.04em;
+  }
+
+  /* Sections */
+  .section { margin-bottom: 128px; }
+  .section-label {
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+    color: var(--slate-400);
+    margin-bottom: 24px;
+  }
+
+  /* Narrative + KPIs */
+  .summary {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 48px;
+    align-items: start;
+  }
+  @media (min-width: 768px) {
+    .summary { grid-template-columns: 1fr 240px; }
+  }
+  .narrative {
+    font-family: 'Playfair Display', serif;
+    font-size: 26px;
+    line-height: 1.45;
+    color: var(--slate-900);
+  }
+  .narrative .highlight {
+    background: var(--amber-50);
+    color: var(--amber-700);
+    padding: 1px 6px;
+    border-radius: 3px;
+  }
+  .kpi-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+  }
+  @media (min-width: 768px) {
+    .kpi-stack { border-left: 1px solid var(--slate-200); padding-left: 32px; }
+  }
+  .kpi-item .kpi-value {
+    font-size: 36px;
+    font-weight: 300;
+    color: var(--slate-900);
+    letter-spacing: -0.02em;
+  }
+  .kpi-item .kpi-label {
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.15em;
+    color: var(--slate-500);
+    margin-top: 2px;
+  }
+
+  /* Taxonomy bars */
+  .taxonomy-list { display: flex; flex-direction: column; gap: 20px; }
+  .tax-row { display: grid; grid-template-columns: 24px 1fr 52px; gap: 12px; align-items: center; }
+  .tax-rank {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 12px;
+    color: var(--slate-400);
+    text-align: right;
+  }
+  .tax-body { display: flex; flex-direction: column; gap: 6px; }
+  .tax-label { font-size: 14px; font-weight: 500; color: var(--slate-800); }
+  .tax-bar-track { height: 4px; background: var(--slate-100); border-radius: 100px; overflow: hidden; }
+  .tax-bar-fill { height: 100%; border-radius: 100px; transition: width 0.6s ease; }
+  .tax-bar-fill.top { background: var(--amber-500); }
+  .tax-bar-fill.rest { background: var(--slate-300); }
+  .tax-pct {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 12px;
+    color: var(--slate-500);
+    text-align: right;
+  }
+  .tax-quote {
+    font-size: 12px;
+    font-style: italic;
+    color: var(--slate-500);
+    margin-top: 2px;
+  }
+
+  /* Evolution timeline */
+  .evolution-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 24px;
+  }
+  @media (min-width: 768px) { .evolution-grid { grid-template-columns: repeat(3, 1fr); } }
+  .evo-card {
+    background: white;
+    border: 1px solid var(--slate-200);
+    border-radius: 16px;
+    padding: 28px;
+  }
+  .evo-card .evo-month {
+    font-family: 'Playfair Display', serif;
+    font-size: 20px;
+    color: var(--slate-900);
+    margin-bottom: 4px;
+  }
+  .evo-card .evo-theme {
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    margin-bottom: 16px;
+  }
+  .evo-card .evo-desc {
+    font-size: 14px;
+    color: var(--slate-600);
+    line-height: 1.6;
+  }
+  .evo-card .evo-stat {
+    margin-top: 16px;
+    padding-top: 16px;
+    border-top: 1px solid var(--slate-100);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 12px;
+    color: var(--slate-500);
+  }
+  .evo-jan .evo-theme { color: var(--slate-600); }
+  .evo-feb .evo-theme { color: var(--amber-600); }
+  .evo-mar .evo-theme { color: var(--indigo-600); }
+
+  /* Quality comparison */
+  .quality-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 24px;
+  }
+  @media (min-width: 768px) { .quality-grid { grid-template-columns: 1fr 1fr; } }
+  .q-card {
+    border-radius: 24px;
+    padding: 36px;
+  }
+  .q-card.good {
+    background: color-mix(in srgb, var(--emerald-50) 50%, transparent);
+    border: 1px solid var(--emerald-100);
+  }
+  .q-card.bad {
+    background: color-mix(in srgb, var(--rose-50) 50%, transparent);
+    border: 1px solid var(--rose-100);
+  }
+  .q-card .q-icon { font-size: 20px; margin-bottom: 12px; }
+  .q-card .q-title {
+    font-family: 'Playfair Display', serif;
+    font-size: 22px;
+    margin-bottom: 20px;
+  }
+  .q-card.good .q-title { color: var(--emerald-900); }
+  .q-card.bad .q-title { color: var(--rose-900); }
+  .q-list { list-style: none; display: flex; flex-direction: column; gap: 14px; }
+  .q-list li {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    font-size: 14px;
+    line-height: 1.6;
+  }
+  .q-card.good .q-list li { color: color-mix(in srgb, var(--emerald-800) 90%, transparent); }
+  .q-card.bad .q-list li { color: color-mix(in srgb, var(--rose-800) 90%, transparent); }
+  .q-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    margin-top: 7px;
+  }
+  .q-card.good .q-dot { background: var(--emerald-400); }
+  .q-card.bad .q-dot { background: var(--rose-400); }
+
+  /* Phrases */
+  .phrases-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 12px;
+  }
+  @media (min-width: 768px) { .phrases-grid { grid-template-columns: repeat(3, 1fr); } }
+  .phrase-chip {
+    background: white;
+    border: 1px solid var(--slate-200);
+    border-radius: 12px;
+    padding: 14px 16px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+  }
+  .phrase-text {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 12px;
+    color: var(--slate-700);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .phrase-count {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px;
+    color: var(--slate-400);
+    flex-shrink: 0;
+  }
+
+  /* Dark action panel */
+  .action-panel {
+    background: var(--slate-900);
+    color: white;
+    border-radius: 24px;
+    padding: 40px;
+    box-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+  }
+  @media (min-width: 768px) { .action-panel { padding: 56px; } }
+  .action-panel .section-label { color: var(--slate-500); }
+  .action-panel .ap-intro {
+    font-family: 'Playfair Display', serif;
+    font-size: 22px;
+    color: white;
+    line-height: 1.4;
+    margin-bottom: 32px;
+    max-width: 640px;
+  }
+  .prompt-block {
+    background: color-mix(in srgb, var(--slate-800) 80%, transparent);
+    border: 1px solid color-mix(in srgb, var(--slate-700) 50%, transparent);
+    border-radius: 16px;
+    overflow: hidden;
+  }
+  .prompt-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 20px;
+    border-bottom: 1px solid color-mix(in srgb, var(--slate-700) 30%, transparent);
+  }
+  .prompt-header-label {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 12px;
+    color: var(--slate-400);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .prompt-header-label svg { width: 14px; height: 14px; }
+  .copy-btn {
+    background: none;
+    border: none;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 12px;
+    color: var(--slate-400);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    transition: color 0.2s;
+  }
+  .copy-btn:hover { color: white; }
+  .copy-btn.copied { color: var(--emerald-400); }
+  .prompt-body {
+    padding: 20px;
+    max-height: 480px;
+    overflow-y: auto;
+  }
+  .prompt-body pre {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 13px;
+    line-height: 1.7;
+    color: color-mix(in srgb, var(--amber-200) 90%, transparent);
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+  .prompt-body pre .comment {
+    color: var(--slate-500);
+  }
+
+  /* Glow card */
+  .glow-wrap {
+    position: relative;
+    margin-top: 48px;
+  }
+  .glow-bg {
+    position: absolute;
+    inset: -2px;
+    background: linear-gradient(135deg, var(--indigo-500), var(--purple-600));
+    border-radius: 26px;
+    opacity: 0.15;
+    filter: blur(16px);
+    transition: opacity 0.5s;
+  }
+  .glow-wrap:hover .glow-bg { opacity: 0.25; }
+  .glow-card {
+    position: relative;
+    background: white;
+    border: 1px solid var(--slate-200);
+    border-radius: 24px;
+    padding: 32px 36px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 20px;
+  }
+  .glow-card .gc-text {
+    font-family: 'Playfair Display', serif;
+    font-size: 18px;
+    font-weight: 500;
+    color: var(--slate-900);
+    line-height: 1.5;
+    max-width: 640px;
+  }
+  .glow-card .gc-text em {
+    font-style: italic;
+    color: var(--indigo-600);
+  }
+
+  /* Footer */
+  footer {
+    border-top: 1px solid var(--slate-200);
+    padding-top: 48px;
+    margin-top: 0;
+    text-align: center;
+  }
+  footer p {
+    font-family: 'Playfair Display', serif;
+    font-style: italic;
+    font-size: 15px;
+    color: var(--slate-400);
+  }
+
+  /* Scrollbar in dark code block */
+  .prompt-body::-webkit-scrollbar { width: 6px; }
+  .prompt-body::-webkit-scrollbar-track { background: transparent; }
+  .prompt-body::-webkit-scrollbar-thumb { background: var(--slate-700); border-radius: 3px; }
+</style>
+</head>
+<body>
+<div class="container">
+
+  <header>
+    <div>
+      <h1>What 370 Files Reveal About<br>How You Plan</h1>
+      <div class="meta" style="margin-top: 8px;">backnotprop/plannotator &middot; Jan 7 &ndash; Mar 18, 2026</div>
+    </div>
+    <div class="meta" style="text-align: right;">
+      <span class="font-mono" style="font-size: 12px;">202 denials &middot; 168 annotations &middot; 71 days</span>
+    </div>
+  </header>
+
+  <!-- 1. Narrative + KPIs -->
+  <div class="section">
+    <div class="section-label">1. The story in the data</div>
+    <div class="summary">
+      <div class="narrative">
+        Across 71 days you denied or revised <span class="highlight">202 plans</span> before any code was written. The single most common reason&mdash;appearing in 1 out of 4 denials&mdash;was the same: the agent jumped to implementation without telling you <em>what</em> it was building, <em>why</em>, or <em>how</em>. Missing narrative. Missing context. Missing the story. Your expectations evolved from &ldquo;does it work?&rdquo; in January to &ldquo;tell me the story and be confident&rdquo; by March.
+      </div>
+      <div class="kpi-stack">
+        <div class="kpi-item">
+          <div class="kpi-value">25.7%</div>
+          <div class="kpi-label">Denials for missing narrative</div>
+        </div>
+        <div class="kpi-item">
+          <div class="kpi-value">50%</div>
+          <div class="kpi-label">Plans revised before coding</div>
+        </div>
+        <div class="kpi-item">
+          <div class="kpi-value">12</div>
+          <div class="kpi-label">Distinct denial categories</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 2. Denial Taxonomy -->
+  <div class="section">
+    <div class="section-label">2. Why plans get denied</div>
+    <div class="taxonomy-list">
+      <div class="tax-row">
+        <span class="tax-rank">1</span>
+        <div class="tax-body">
+          <span class="tax-label">Missing Narrative / Overview</span>
+          <div class="tax-bar-track"><div class="tax-bar-fill top" style="width: 100%"></div></div>
+          <span class="tax-quote">"This plan is denied without narrative detail and rationales."</span>
+        </div>
+        <span class="tax-pct">25.7%</span>
+      </div>
+      <div class="tax-row">
+        <span class="tax-rank">2</span>
+        <div class="tax-body">
+          <span class="tax-label">Clarification Needed</span>
+          <div class="tax-bar-track"><div class="tax-bar-fill rest" style="width: 65%"></div></div>
+          <span class="tax-quote">"What does this Mean???"</span>
+        </div>
+        <span class="tax-pct">16.8%</span>
+      </div>
+      <div class="tax-row">
+        <span class="tax-rank">3</span>
+        <div class="tax-body">
+          <span class="tax-label">Testing / Procedural</span>
+          <div class="tax-bar-track"><div class="tax-bar-fill rest" style="width: 54%"></div></div>
+          <span class="tax-quote">"I'm denying so you can create a diff."</span>
+        </div>
+        <span class="tax-pct">13.9%</span>
+      </div>
+      <div class="tax-row">
+        <span class="tax-rank">4</span>
+        <div class="tax-body">
+          <span class="tax-label">Wrong Approach / Over-Engineered</span>
+          <div class="tax-bar-track"><div class="tax-bar-fill rest" style="width: 37%"></div></div>
+          <span class="tax-quote">"Why are we doing difficult shit here? I want a hover experience."</span>
+        </div>
+        <span class="tax-pct">9.4%</span>
+      </div>
+      <div class="tax-row">
+        <span class="tax-rank">5</span>
+        <div class="tax-body">
+          <span class="tax-label">Process Requirement</span>
+          <div class="tax-bar-track"><div class="tax-bar-fill rest" style="width: 31%"></div></div>
+          <span class="tax-quote">"Make sure you feature branch."</span>
+        </div>
+        <span class="tax-pct">7.9%</span>
+      </div>
+      <div class="tax-row">
+        <span class="tax-rank">6</span>
+        <div class="tax-body">
+          <span class="tax-label">Confidence / Risk Check</span>
+          <div class="tax-bar-track"><div class="tax-bar-fill rest" style="width: 29%"></div></div>
+          <span class="tax-quote">"Take a step back, breathe, make sure we're not being irrational."</span>
+        </div>
+        <span class="tax-pct">7.4%</span>
+      </div>
+      <div class="tax-row">
+        <span class="tax-rank">7</span>
+        <div class="tax-body">
+          <span class="tax-label">Content Removal</span>
+          <div class="tax-bar-track"><div class="tax-bar-fill rest" style="width: 27%"></div></div>
+          <span class="tax-quote">"I don't want this in the plan."</span>
+        </div>
+        <span class="tax-pct">6.9%</span>
+      </div>
+      <div class="tax-row">
+        <span class="tax-rank">8</span>
+        <div class="tax-body">
+          <span class="tax-label">Implementation Bug Found</span>
+          <div class="tax-bar-track"><div class="tax-bar-fill rest" style="width: 23%"></div></div>
+        </div>
+        <span class="tax-pct">5.9%</span>
+      </div>
+      <div class="tax-row">
+        <span class="tax-rank">9</span>
+        <div class="tax-body">
+          <span class="tax-label">Design / UX Issue</span>
+          <div class="tax-bar-track"><div class="tax-bar-fill rest" style="width: 21%"></div></div>
+        </div>
+        <span class="tax-pct">5.4%</span>
+      </div>
+      <div class="tax-row">
+        <span class="tax-rank">10</span>
+        <div class="tax-body">
+          <span class="tax-label">Naming / Terminology</span>
+          <div class="tax-bar-track"><div class="tax-bar-fill rest" style="width: 16%"></div></div>
+          <span class="tax-quote">"Why do you keep calling it Simplified????"</span>
+        </div>
+        <span class="tax-pct">4.0%</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- 3. Evolution -->
+  <div class="section">
+    <div class="section-label">3. How your expectations evolved</div>
+    <div class="evolution-grid">
+      <div class="evo-card evo-jan">
+        <div class="evo-month">January</div>
+        <div class="evo-theme">"Does it work?"</div>
+        <div class="evo-desc">Bug-hunting phase. You were hands-on testing View Logs, iterating on session scoping heuristics. 60% of denials were implementation bugs and verification failures. No mention of &ldquo;narrative&rdquo; or &ldquo;overview&rdquo; yet.</div>
+        <div class="evo-stat">26 denials &middot; 0 narrative requests</div>
+      </div>
+      <div class="evo-card evo-feb">
+        <div class="evo-month">February</div>
+        <div class="evo-theme">"Follow the process"</div>
+        <div class="evo-desc">Process gates emerged: feature branches, Linear tickets, pull main. 40% of denials were procedural (diff testing). UX polish intensified. The first narrative demands appeared: &ldquo;I want a narrative under each section.&rdquo;</div>
+        <div class="evo-stat">48 denials &middot; 6 narrative requests</div>
+      </div>
+      <div class="evo-card evo-mar">
+        <div class="evo-month">March</div>
+        <div class="evo-theme">"Tell me the story"</div>
+        <div class="evo-desc">Narrative became the #1 gate. You created a &ldquo;Missing overview&rdquo; label and applied it systematically. Confidence checks became standard. You began telling agents to &ldquo;take a step back, breathe, and analyze.&rdquo;</div>
+        <div class="evo-stat">128 denials &middot; 25+ narrative requests</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 4. Quality comparison -->
+  <div class="section">
+    <div class="section-label">4. What works vs. what doesn't</div>
+    <div class="quality-grid">
+      <div class="q-card good">
+        <div class="q-icon">&#10003;</div>
+        <div class="q-title">What approved plans do</div>
+        <ul class="q-list">
+          <li><span class="q-dot"></span>Lead with a narrative overview: what exists, what changes, why</li>
+          <li><span class="q-dot"></span>State confidence and identify risks proactively</li>
+          <li><span class="q-dot"></span>Reference existing codebase patterns before proposing new code</li>
+          <li><span class="q-dot"></span>Use explicit, transparent naming (not euphemisms)</li>
+          <li><span class="q-dot"></span>Break large work into phases with evaluation gates</li>
+          <li><span class="q-dot"></span>Include example output for user-facing changes</li>
+          <li><span class="q-dot"></span>Specify feature branch and ticket creation steps</li>
+        </ul>
+      </div>
+      <div class="q-card bad">
+        <div class="q-icon">&#10007;</div>
+        <div class="q-title">What agents keep getting wrong</div>
+        <ul class="q-list">
+          <li><span class="q-dot"></span>Jump to implementation steps without narrative context</li>
+          <li><span class="q-dot"></span>Over-engineer: Shift+Click when hover works, MCP tool when a README suffices</li>
+          <li><span class="q-dot"></span>Introduce new code for things the codebase already solves</li>
+          <li><span class="q-dot"></span>Propose work on top of failing lint/type checks</li>
+          <li><span class="q-dot"></span>Use vague or euphemistic naming (&ldquo;Accept&rdquo; instead of &ldquo;Git Add&rdquo;)</li>
+          <li><span class="q-dot"></span>Wait to be asked for confidence instead of stating it</li>
+          <li><span class="q-dot"></span>Rush to modify instead of reporting what they see</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <!-- 5. The actionable output -->
+  <div class="section">
+    <div class="section-label">5. The actionable output</div>
+    <div class="narrative" style="margin-bottom: 32px;">
+      The analysis produced <span class="highlight">17 specific prompt instructions</span> that, if embedded in a planning prompt, would address ~70% of all denial reasons. The biggest three:
+    </div>
+    <div style="display: flex; flex-direction: column; gap: 20px;">
+      <div style="display: flex; gap: 16px; align-items: flex-start;">
+        <span class="font-mono" style="font-size: 24px; font-weight: 300; color: var(--amber-500); flex-shrink: 0; width: 32px; text-align: right;">1</span>
+        <div>
+          <div style="font-size: 17px; font-weight: 500; color: var(--slate-900); margin-bottom: 4px;">Every plan MUST start with a Solution Overview</div>
+          <div style="font-size: 14px; color: var(--slate-600); line-height: 1.5;">What exists, what changes, why, how. This alone addresses 1 in 4 denials.</div>
+        </div>
+      </div>
+      <div style="display: flex; gap: 16px; align-items: flex-start;">
+        <span class="font-mono" style="font-size: 24px; font-weight: 300; color: var(--amber-500); flex-shrink: 0; width: 32px; text-align: right;">2</span>
+        <div>
+          <div style="font-size: 17px; font-weight: 500; color: var(--slate-900); margin-bottom: 4px;">End every plan with a Confidence Assessment</div>
+          <div style="font-size: 14px; color: var(--slate-600); line-height: 1.5;">Don&rsquo;t wait to be asked. State your confidence, identify risks, flag uncertainties.</div>
+        </div>
+      </div>
+      <div style="display: flex; gap: 16px; align-items: flex-start;">
+        <span class="font-mono" style="font-size: 24px; font-weight: 300; color: var(--amber-500); flex-shrink: 0; width: 32px; text-align: right;">3</span>
+        <div>
+          <div style="font-size: 17px; font-weight: 500; color: var(--slate-900); margin-bottom: 4px;">Search for existing patterns before proposing new code</div>
+          <div style="font-size: 14px; color: var(--slate-600); line-height: 1.5;">Explicitly state what you found in the codebase. Prefer reuse over new implementation.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 6. Recurring phrases -->
+  <div class="section">
+    <div class="section-label">6. Your most-used phrases</div>
+    <div class="phrases-grid">
+      <div class="phrase-chip"><span class="phrase-text">"narrative"</span><span class="phrase-count">50+</span></div>
+      <div class="phrase-chip"><span class="phrase-text">"I don't want this in the plan"</span><span class="phrase-count">10</span></div>
+      <div class="phrase-chip"><span class="phrase-text">"feature branch"</span><span class="phrase-count">8+</span></div>
+      <div class="phrase-chip"><span class="phrase-text">"confidence"</span><span class="phrase-count">8+</span></div>
+      <div class="phrase-chip"><span class="phrase-text">"Missing overview"</span><span class="phrase-count">14</span></div>
+      <div class="phrase-chip"><span class="phrase-text">"front-end design skill"</span><span class="phrase-count">16</span></div>
+      <div class="phrase-chip"><span class="phrase-text">"separation of concerns"</span><span class="phrase-count">6</span></div>
+      <div class="phrase-chip"><span class="phrase-text">"Take a step back, breathe"</span><span class="phrase-count">6</span></div>
+      <div class="phrase-chip"><span class="phrase-text">"how does this work"</span><span class="phrase-count">5+</span></div>
+      <div class="phrase-chip"><span class="phrase-text">"what the fuck"</span><span class="phrase-count">4</span></div>
+      <div class="phrase-chip"><span class="phrase-text">"create a ticket"</span><span class="phrase-count">4+</span></div>
+      <div class="phrase-chip"><span class="phrase-text">"reusable"</span><span class="phrase-count">19+</span></div>
+    </div>
+  </div>
+
+  <!-- 7. Corrective Prompt -->
+  <div class="section" style="margin-bottom: 64px;">
+    <div class="action-panel">
+      <div class="section-label">7. The corrective prompt</div>
+      <div class="ap-intro">
+        These 17 instructions were extracted directly from your denial patterns. Embedding them in a planning prompt would address approximately 70% of all denial reasons.
+      </div>
+      <div class="prompt-block">
+        <div class="prompt-header">
+          <span class="prompt-header-label">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+            planning-instructions.md
+          </span>
+          <button class="copy-btn" onclick="copyPrompt(this)">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
+            Copy
+          </button>
+        </div>
+        <div class="prompt-body">
+          <pre id="prompt-content"><span class="comment"># Planning Instructions
+# Derived from 370 files of denial & annotation analysis</span>
+
+1. STRUCTURE: Every plan MUST begin with a "Solution Overview"
+   containing 2-3 paragraphs of narrative prose explaining:
+   - What exists today (current state)
+   - What will change and why
+   - How it will be built (approach summary)
+   Do NOT skip this. Do NOT replace it with bullet points.
+
+2. NARRATIVE: Every major section must include a rationale
+   paragraph — not just what will be done, but WHY this
+   approach was chosen over alternatives.
+
+3. FEATURE BRANCH: Always specify implementation will occur
+   on a feature branch. State the branch name. Never plan
+   to work directly on main.
+
+4. EXISTING PATTERNS: Before proposing any new implementation,
+   search the codebase for existing patterns that solve the
+   same problem. Explicitly state what you found and whether
+   you will reuse it. Prefer reuse over new code.
+
+5. CONFIDENCE STATEMENT: End the plan with a "Confidence
+   Assessment" section. State your confidence level, identify
+   risks or edge cases, and note uncertainties. Do not wait
+   to be asked.
+
+6. PHASING: For plans with more than 3 steps, break them into
+   numbered phases. After each phase, note "Pause for
+   evaluation" so the reviewer can assess before proceeding.
+
+7. ISSUE TRACKING: If the project uses Linear or GitHub Issues,
+   include a step to create relevant tickets BEFORE
+   implementation. Backlog items should be separate tickets.
+
+8. SIMPLICITY: Choose the simplest approach that meets
+   requirements. Do not introduce modifier keys when hover
+   works. Do not build a framework when a README suffices.
+
+9. NAMING: Use explicit, transparent names for user-facing
+   features. Do not euphemize Git operations ("Git Add"
+   not "Accept"). Match existing product naming conventions.
+
+10. CODE QUALITY: State that implementation will follow clean
+    code principles: modular architecture, separation of
+    concerns, no circumventing lint or type checks.
+
+11. CLEAN FOUNDATION: If the codebase has failing lint or type
+    checks, address these BEFORE proposing new features. State
+    the current CI/CD state.
+
+12. PRIVACY: For features involving data storage or sharing,
+    explicitly state privacy guarantees. Require user
+    confirmation before storing data.
+
+13. EXAMPLES: When the plan involves user-facing output or UI,
+    include an example of what it will look like.
+
+14. FOCUSED SCOPE: Do not include sections that are obvious,
+    boilerplate, or previously asked to be removed. Keep the
+    plan focused rather than comprehensive.
+
+15. DESIGN SKILL: For any frontend/UI work, invoke the
+    front-end design skill to validate the approach. Note
+    this invocation explicitly in the plan.
+
+16. VERIFICATION STEP: For refactors or multi-file changes,
+    include a verification step with line-by-line comparison
+    of affected code paths.
+
+17. DELIBERATION: If the plan involves a dramatic shift, state
+    that you have re-evaluated the approach, traced through
+    affected files mentally, and are confident in the plan.
+    Do not rush.</pre>
+        </div>
+      </div>
+
+      <div class="glow-wrap">
+        <div class="glow-bg"></div>
+        <div class="glow-card">
+          <div class="gc-text">
+            These instructions are yours &mdash; derived from <em>your feedback, your language, your standards</em>. Copy them into your planning prompt and watch the deny rate drop.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <footer>
+    <p>Analysis of 202 denied plans and 168 annotation files from the Plannotator archive.</p>
+  </footer>
+
+</div>
+
+<script>
+function copyPrompt(btn) {
+  const text = document.getElementById('prompt-content').textContent;
+  navigator.clipboard.writeText(text).then(() => {
+    btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg> Copied';
+    btn.classList.add('copied');
+    setTimeout(() => {
+      btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg> Copy';
+      btn.classList.remove('copied');
+    }, 2000);
+  });
+}
+</script>
+</body>
+</html>

--- a/claude/skills/plannotator-compound/references/claude-code-fallback.md
+++ b/claude/skills/plannotator-compound/references/claude-code-fallback.md
@@ -1,0 +1,282 @@
+# Claude Code Fallback
+
+Read this file only when the user does **not** have a usable Plannotator archive.
+
+This is the secondary path for ordinary Claude Code users whose denial history
+exists in `~/.claude/projects/` rather than the Plannotator plans directory (`$PLANNOTATOR_DATA_DIR/plans/` or `~/.plannotator/plans/`).
+
+The goal is the same as the main skill:
+
+- extract the user's real denial reasons
+- reduce them into a taxonomy and prompt corrections
+- produce the same HTML report design and section flow
+
+## Source of Truth
+
+Use the bundled parser at:
+
+- [scripts/extract_exit_plan_mode_outcomes.py](../scripts/extract_exit_plan_mode_outcomes.py)
+
+Resolve that script path relative to this skill directory before running it.
+
+This script normalizes `ExitPlanMode` outcomes from Claude Code JSONL transcripts
+and emits clean JSON parts containing only human-authored denial reasons by default.
+
+Do **not** read raw `~/.claude/projects/**/*.jsonl` directly unless:
+
+- the parser fails
+- the user asks for audit-level verification
+- you need to inspect one or two suspicious records by hand
+
+The parser exists specifically to strip transcript noise such as generic native
+reject strings and wrapper boilerplate.
+
+## Run the Parser
+
+Create the working directory first:
+
+```bash
+mkdir -p /tmp/compound-planning
+```
+
+Then run the bundled parser. Prefer `python3`; if unavailable, use `python`.
+
+Use a resolved absolute script path, not a repo-local copy.
+
+```bash
+python3 [RESOLVED SKILL PATH]/scripts/extract_exit_plan_mode_outcomes.py \
+  --projects-dir ~/.claude/projects \
+  --json-out /tmp/compound-planning/claude-code-human-reasons.json \
+  --show-samples 0
+```
+
+Expected output:
+
+- manifest:
+  `/tmp/compound-planning/claude-code-human-reasons/claude-code-human-reasons.manifest.json`
+- part files:
+  `/tmp/compound-planning/claude-code-human-reasons/claude-code-human-reasons.part-XXXX-of-XXXX.json`
+
+The script prints how many records were detected and how many JSON part files were emitted.
+
+## What To Read First
+
+Read the manifest before reading any part file.
+
+The manifest gives you:
+
+- total filtered record count
+- total `ExitPlanMode` attempts
+- native approval / denial counts
+- non-native denial counts
+- part file list
+
+Use the part files only after you understand the overall dataset shape.
+
+## Inventory In Fallback Mode
+
+In Claude Code fallback mode, report this dataset instead of the Plannotator file counts:
+
+- human denial reasons found
+- total `ExitPlanMode` attempts scanned
+- native approvals
+- native denials with extractable inline reason
+- native denials without recoverable reason
+- non-native denials with recoverable payload
+- number of emitted JSON parts
+- date range from the records
+- total days spanned
+- distinct sessions
+- distinct project roots / `cwd` values
+
+Also calculate:
+
+- average `plan_length_chars` where present
+- percentage of all denials that contain a recoverable human reason
+
+Do **not** fabricate Plannotator-only inventory fields in fallback mode:
+
+- no `*-approved.md` counts
+- no `*.annotations.md` counts
+- no `*.diff.md` counts
+- no approved-plan line-count analysis
+
+If the user asks for those specifically, state that Claude Code log fallback mode
+does not contain those artifacts.
+
+### Previous Report Detection In Fallback Mode
+
+Previous report detection still applies. Check the user's home directory or
+the Plannotator plans directory (`${PLANNOTATOR_DATA_DIR:-~/.plannotator}/plans/`) for existing `compound-planning-report*.html` files. If
+found, offer the same incremental vs full choice as Plannotator mode. In
+incremental mode, filter the parser output by timestamp rather than by filename
+date — use the `timestamp` field in each JSON record.
+
+If no previous report exists, use the first-report naming convention
+(`compound-planning-report.html`). Otherwise use the next version number.
+
+## Extraction In Fallback Mode
+
+Treat the emitted JSON part files as the clean source dataset.
+
+### Batching
+
+- **Small datasets (< 200 records):** read the part files directly without extra agents
+- **Medium datasets (200-800 records):** split by part file or time range into 2-4 agents
+- **Large datasets (800+ records):** split by part file groups or balanced time ranges
+
+All extraction agents should use `model: "haiku"` — they're doing straightforward
+file reading and structured extraction, not reasoning.
+
+Each extraction agent should read every record in its assigned part files and write
+clean markdown output to:
+
+```text
+/tmp/compound-planning/extraction-{batch-name}.md
+```
+
+### Extraction Prompt For Claude Code Denial Records
+
+Use this prompt for each fallback extraction batch (adapt the part files and output path):
+
+```text
+You are extracting structured data from Claude Code ExitPlanMode denial records.
+
+Files to read: [JSON PART FILES]
+Output: Write your complete results to [OUTPUT FILE PATH]
+
+Read EVERY record in the assigned files. Each record already contains a cleaned
+human_reason field. Use that as the primary source text.
+
+For EACH record, extract:
+- Date
+- Session ID
+- Project / cwd
+- Topic (only if inferable from the reason or plan path; otherwise say "Unknown from logs")
+- Human denial reason
+- What was specifically asked to change
+- Feedback type (let the content determine the category)
+- Notable phrases
+- Reason source (`native_inline_reason`, `non_native_freeform_payload`, or `structured_quote_extraction`)
+- Plan path if present
+- Plan length in chars if present
+
+Do NOT skip any records. One entry per record.
+
+Format each entry as:
+**[session_id :: tool_use_id]**
+- Date: ...
+- Project: ...
+- Topic: ...
+- Human denial reason: ...
+- Feedback type: ...
+- Specific asks: ...
+- Notable phrases: ...
+- Reason source: ...
+- Plan path: ...
+- Plan length chars: ...
+---
+
+After processing all records, write the complete results to [OUTPUT FILE PATH].
+State the total record count at the end of the file.
+```
+
+## Reduction In Fallback Mode
+
+The reduction step stays conceptually the same:
+
+- taxonomy
+- top patterns
+- recurring phrases
+- reviewer values
+- recurring agent mistakes
+- structural requests
+- evolution over time
+- corrective prompt instructions
+
+Use `model: "sonnet"` for reduction agents, same as Plannotator mode. The
+two-stage reduce (partial reduces for 21+ extraction files) also applies when
+there are many part files.
+
+But interpret the dataset correctly:
+
+- this is denial-reason evidence from Claude Code logs
+- not every denial has a recoverable human reason
+- annotations may be absent entirely
+- success traits are often inferred from the inverse of repeated denial feedback
+
+If the evidence for "what works" is weaker than the evidence for "what fails",
+say that explicitly.
+
+## HTML Report Adaptation
+
+Use the same template and the same section order as the main skill.
+
+In fallback mode:
+
+- explicitly state in the header/meta that the source is Claude Code `ExitPlanMode`
+  denial reasons
+- keep the same narrative-first editorial style
+- keep the same 7 major sections
+- use real denial-reason counts, dates, phrases, and percentages only
+
+### KPI Sidebar Substitutes
+
+The Plannotator version uses a revision-rate KPI that may not exist here.
+
+In fallback mode, prefer this KPI trio:
+
+1. top denial category percentage
+2. total human denial reasons recovered
+3. number of distinct denial categories
+
+If a better third metric emerges from the data, use it, but do not invent one.
+
+### Footer / Provenance
+
+The footer tagline should mention that the report was derived from Claude Code
+denial reasons rather than Plannotator markdown archives.
+
+### Important Limitation To State
+
+If `human_reasons_total < total denials`, mention in the narrative or footer note
+that some denials in the transcript did not contain recoverable human-authored
+feedback and therefore could not contribute to the pattern analysis.
+
+### Versioned Report Naming
+
+Versioned naming (`v2`, `v3`, etc.) applies to fallback mode too. Save reports
+to the Plannotator plans directory (`${PLANNOTATOR_DATA_DIR:-~/.plannotator}/plans/`, create the directory if it doesn't exist) so that
+all compound planning reports live in the same location regardless of data source.
+
+## Summary In Fallback Mode
+
+At the end, tell the user:
+
+- how many human denial reasons were analyzed
+- how many total `ExitPlanMode` attempts were scanned
+- the top 3 denial patterns found
+- the estimated percentage of denial reasons the corrective instructions address
+- the single most impactful prompt improvement
+- where the report was saved (including version number)
+- if incremental: note that earlier findings are in the previous report
+
+## Improvement Hook In Fallback Mode
+
+The Phase 6 improvement hook applies to fallback mode too. The corrective prompt
+instructions derived from Claude Code denial reasons are just as useful for
+injection into future planning sessions. Follow the same flow as the main skill.
+
+## Audit Mode
+
+Only if the user asks for raw denial records or transcript noise:
+
+```bash
+python3 [RESOLVED SKILL PATH]/scripts/extract_exit_plan_mode_outcomes.py \
+  --projects-dir ~/.claude/projects \
+  --records-filter denials \
+  --json-out /tmp/compound-planning/claude-code-all-denials.json \
+  --show-samples 0
+```
+
+Do not use this audit-mode output for the normal report unless the user asks for it.

--- a/claude/skills/plannotator-compound/scripts/extract_exit_plan_mode_outcomes.py
+++ b/claude/skills/plannotator-compound/scripts/extract_exit_plan_mode_outcomes.py
@@ -1,0 +1,820 @@
+#!/usr/bin/env python3
+"""Extract ExitPlanMode outcomes from Claude Code JSONL session logs.
+
+This parser keeps three views of the same data:
+
+1. Strict native Claude Code classification
+   - native approval:
+     "User has approved your plan."
+   - native denial:
+     "The user doesn't want to proceed with this tool use. The tool use was rejected"
+
+2. General denial capture
+   - any matching ExitPlanMode tool_result with is_error=true and non-empty text
+     is captured as a denial/error payload, even when it is custom hook output
+     or some other non-native integration.
+
+3. Human-reason extraction
+   - native inline reasons are preserved as-is
+   - freeform non-native error payloads are treated as human reasons
+   - structured non-native payloads are reduced to quoted feedback where possible
+
+This means the script does not depend on hook-specific strings to capture custom
+denials, but it also does not dump wrapper boilerplate into the human-reason
+output.
+
+The script streams JSONL line-by-line and uses only the Python standard library.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, List, Optional, Tuple
+
+
+APPROVE_PREFIX = "User has approved your plan."
+REJECT_PREFIX = (
+    "The user doesn't want to proceed with this tool use. "
+    "The tool use was rejected"
+)
+REASON_MARKER = "To tell you how to proceed, the user said:\n"
+NOTE_MARKER = (
+    "\n\nNote: The user's next message may contain a correction or preference."
+)
+
+
+@dataclass
+class AttemptRecord:
+    session_id: str
+    tool_use_id: str
+    file_path: str
+    line_number: int
+    timestamp: Optional[str]
+    cwd: Optional[str]
+    plan_file_path: Optional[str]
+    plan_length_chars: Optional[int]
+    outcome: str = "pending"
+    native_reason: Optional[str] = None
+    native_reason_style: Optional[str] = None
+    captured_reason: Optional[str] = None
+    captured_reason_style: Optional[str] = None
+    captured_reason_source: Optional[str] = None
+    human_reason: Optional[str] = None
+    human_reason_style: Optional[str] = None
+    human_reason_source: Optional[str] = None
+    result_is_error: Optional[bool] = None
+    result_file_path: Optional[str] = None
+    result_line_number: Optional[int] = None
+    result_timestamp: Optional[str] = None
+    result_preview: Optional[str] = None
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Extract ExitPlanMode approvals/denials from Claude Code logs."
+    )
+    parser.add_argument(
+        "--projects-dir",
+        default="~/.claude/projects",
+        help="Root Claude projects directory. Default: %(default)s",
+    )
+    parser.add_argument(
+        "--include-subagents",
+        action="store_true",
+        help="Include /subagents/ JSONL files. Default is to skip them.",
+    )
+    parser.add_argument(
+        "--records-filter",
+        choices=("all", "native", "native-denials", "denials", "human-reasons"),
+        default="human-reasons",
+        help=(
+            "Which records to write to JSON/CSV outputs. "
+            "Default: %(default)s"
+        ),
+    )
+    parser.add_argument(
+        "--include-non-native-denials",
+        action="store_true",
+        help=(
+            "Include non-native denial/error payloads in sample output. "
+            "Default sample output shows only native denials."
+        ),
+    )
+    parser.add_argument(
+        "--show-samples",
+        type=int,
+        default=5,
+        help="How many denial samples to print in the text summary.",
+    )
+    parser.add_argument(
+        "--json-out",
+        help="Optional path to write a JSON report.",
+    )
+    parser.add_argument(
+        "--max-output-tokens-per-file",
+        type=int,
+        default=50000,
+        help=(
+            "Approximate max token budget per JSON file when writing --json-out. "
+            "Default: %(default)s"
+        ),
+    )
+    return parser.parse_args()
+
+
+def iter_jsonl_files(root: Path, include_subagents: bool) -> Iterator[Path]:
+    for dirpath, dirnames, filenames in os.walk(root):
+        if not include_subagents and "subagents" in dirnames:
+            dirnames.remove("subagents")
+        dirnames.sort()
+        for filename in sorted(filenames):
+            if filename.endswith(".jsonl"):
+                yield Path(dirpath) / filename
+
+
+def make_attempt_key(session_id: str, tool_use_id: str) -> str:
+    return session_id + "::" + tool_use_id
+
+
+def preview(text: str, limit: int = 220) -> str:
+    compact = " ".join(text.split())
+    if len(compact) <= limit:
+        return compact
+    return compact[: limit - 3] + "..."
+
+
+def estimate_tokens(text: str) -> int:
+    # Rough enough for output chunking. We intentionally bias slightly high.
+    return max(1, (len(text) + 3) // 4)
+
+
+def iter_blocks(message_content: object) -> Iterator[dict]:
+    if not isinstance(message_content, list):
+        return
+    for block in message_content:
+        if isinstance(block, dict):
+            yield block
+
+
+def extract_text(content: object) -> str:
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+
+    parts: List[str] = []
+    for item in content:
+        if isinstance(item, str):
+            parts.append(item)
+            continue
+        if not isinstance(item, dict):
+            continue
+        if isinstance(item.get("text"), str):
+            parts.append(item["text"])
+        elif isinstance(item.get("content"), str):
+            parts.append(item["content"])
+    return "\n".join(part for part in parts if part)
+
+
+def classify_reason_style(reason: Optional[str]) -> Optional[str]:
+    if not reason:
+        return None
+
+    stripped = reason.lstrip()
+    if (
+        stripped.startswith("#")
+        or stripped.startswith("YOUR PLAN WAS NOT APPROVED.")
+        or "\n## " in reason
+        or "\n---" in reason
+    ):
+        return "structured"
+    return "freeform"
+
+
+def extract_blockquote_feedback(text: str) -> List[str]:
+    quotes: List[str] = []
+    current: List[str] = []
+
+    for raw_line in text.splitlines():
+        stripped = raw_line.strip()
+        if stripped.startswith(">"):
+            current.append(stripped[1:].lstrip())
+            continue
+
+        if current:
+            if not stripped or stripped.startswith("## ") or stripped == "---":
+                quote = "\n".join(line for line in current if line).strip()
+                if quote:
+                    quotes.append(quote)
+                current = []
+                continue
+
+            # Preserve wrapped continuation lines that belong to the same quote.
+            current.append(stripped)
+
+    if current:
+        quote = "\n".join(line for line in current if line).strip()
+        if quote:
+            quotes.append(quote)
+
+    return quotes
+
+
+def extract_human_reason(
+    native_reason: Optional[str],
+    captured_reason: Optional[str],
+    captured_reason_style: Optional[str],
+) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+    if native_reason:
+        return (
+            native_reason,
+            classify_reason_style(native_reason),
+            "native_inline_reason",
+        )
+
+    if not captured_reason:
+        return (None, None, None)
+
+    if captured_reason_style == "freeform":
+        return (
+            captured_reason,
+            classify_reason_style(captured_reason),
+            "non_native_freeform_payload",
+        )
+
+    quote_feedback = extract_blockquote_feedback(captured_reason)
+    if quote_feedback:
+        reason = "\n\n".join(quote_feedback)
+        return (
+            reason,
+            classify_reason_style(reason),
+            "structured_quote_extraction",
+        )
+
+    return (None, None, None)
+
+
+def classify_result(
+    text: str,
+    is_error: bool,
+) -> Tuple[str, Optional[str], Optional[str], Optional[str], Optional[str]]:
+    stripped = text.strip()
+    if not stripped:
+        if is_error:
+            return (
+                "denied_non_native_no_payload",
+                None,
+                None,
+                None,
+                None,
+            )
+        return ("pending", None, None, None, None)
+
+    if stripped.startswith(APPROVE_PREFIX):
+        return ("approved_native", None, None, None, None)
+
+    if stripped.startswith(REJECT_PREFIX):
+        marker_index = stripped.find(REASON_MARKER)
+        if marker_index < 0:
+            return ("denied_native_no_reason", None, None, None, None)
+
+        reason = stripped[marker_index + len(REASON_MARKER) :]
+        note_index = reason.find(NOTE_MARKER)
+        if note_index >= 0:
+            reason = reason[:note_index]
+        reason = reason.strip()
+        if reason:
+            style = classify_reason_style(reason)
+            return (
+                "denied_native_with_reason",
+                reason,
+                reason,
+                "native_inline_reason",
+                style,
+            )
+        return ("denied_native_no_reason", None, None, None, None)
+
+    if is_error:
+        style = classify_reason_style(stripped)
+        return (
+            "denied_non_native_with_payload",
+            None,
+            stripped,
+            "non_native_error_payload",
+            style,
+        )
+
+    return ("non_native_other", None, None, None, None)
+
+
+def outcome_rank(outcome: str) -> int:
+    ranks = {
+        "pending": 0,
+        "non_native_other": 1,
+        "approved_native": 2,
+        "denied_native_no_reason": 3,
+        "denied_native_with_reason": 4,
+        "denied_non_native_no_payload": 5,
+        "denied_non_native_with_payload": 6,
+    }
+    return ranks.get(outcome, 0)
+
+
+def update_attempt_from_result(
+    attempt: AttemptRecord,
+    file_path: Path,
+    line_number: int,
+    timestamp: Optional[str],
+    text: str,
+    is_error: bool,
+) -> None:
+    (
+        outcome,
+        native_reason,
+        captured_reason,
+        captured_reason_source,
+        captured_reason_style,
+    ) = classify_result(text=text, is_error=is_error)
+    if outcome_rank(outcome) < outcome_rank(attempt.outcome):
+        return
+
+    attempt.outcome = outcome
+    attempt.native_reason = native_reason
+    attempt.native_reason_style = classify_reason_style(native_reason)
+    attempt.captured_reason = captured_reason
+    attempt.captured_reason_source = captured_reason_source
+    attempt.captured_reason_style = captured_reason_style
+    (
+        attempt.human_reason,
+        attempt.human_reason_style,
+        attempt.human_reason_source,
+    ) = extract_human_reason(
+        native_reason=native_reason,
+        captured_reason=captured_reason,
+        captured_reason_style=captured_reason_style,
+    )
+    attempt.result_is_error = is_error
+    attempt.result_file_path = str(file_path)
+    attempt.result_line_number = line_number
+    attempt.result_timestamp = timestamp
+    attempt.result_preview = preview(text)
+
+
+def scan_projects(
+    projects_dir: Path,
+    include_subagents: bool,
+) -> Tuple[Dict[str, int], List[AttemptRecord]]:
+    stats = {
+        "files_scanned": 0,
+        "lines_scanned": 0,
+        "json_errors": 0,
+    }
+    attempts: Dict[str, AttemptRecord] = {}
+
+    for file_path in iter_jsonl_files(projects_dir, include_subagents):
+        stats["files_scanned"] += 1
+        try:
+            handle = file_path.open("r", encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+
+        with handle:
+            for line_number, raw_line in enumerate(handle, start=1):
+                if not raw_line.strip():
+                    continue
+                stats["lines_scanned"] += 1
+                try:
+                    obj = json.loads(raw_line)
+                except json.JSONDecodeError:
+                    stats["json_errors"] += 1
+                    continue
+
+                session_id = str(obj.get("sessionId") or str(file_path))
+                timestamp = obj.get("timestamp")
+                cwd = obj.get("cwd")
+                message = obj.get("message")
+                if not isinstance(message, dict):
+                    continue
+
+                content = message.get("content")
+
+                for block in iter_blocks(content):
+                    if (
+                        block.get("type") == "tool_use"
+                        and block.get("name") == "ExitPlanMode"
+                        and isinstance(block.get("id"), str)
+                    ):
+                        tool_use_id = block["id"]
+                        key = make_attempt_key(session_id, tool_use_id)
+                        if key in attempts:
+                            continue
+                        input_data = block.get("input")
+                        plan = None
+                        plan_file_path = None
+                        if isinstance(input_data, dict):
+                            if isinstance(input_data.get("plan"), str):
+                                plan = input_data["plan"]
+                            if isinstance(input_data.get("planFilePath"), str):
+                                plan_file_path = input_data["planFilePath"]
+
+                        attempts[key] = AttemptRecord(
+                            session_id=session_id,
+                            tool_use_id=tool_use_id,
+                            file_path=str(file_path),
+                            line_number=line_number,
+                            timestamp=timestamp if isinstance(timestamp, str) else None,
+                            cwd=cwd if isinstance(cwd, str) else None,
+                            plan_file_path=plan_file_path,
+                            plan_length_chars=len(plan) if isinstance(plan, str) else None,
+                        )
+
+                if message.get("role") != "user":
+                    continue
+
+                for block in iter_blocks(content):
+                    if (
+                        block.get("type") != "tool_result"
+                        or not isinstance(block.get("tool_use_id"), str)
+                    ):
+                        continue
+
+                    key = make_attempt_key(session_id, block["tool_use_id"])
+                    attempt = attempts.get(key)
+                    if attempt is None:
+                        continue
+
+                    text = extract_text(block.get("content"))
+                    update_attempt_from_result(
+                        attempt=attempt,
+                        file_path=file_path,
+                        line_number=line_number,
+                        timestamp=timestamp if isinstance(timestamp, str) else None,
+                        text=text,
+                        is_error=bool(block.get("is_error")),
+                    )
+
+    return stats, list(attempts.values())
+
+
+def summarize(attempts: Iterable[AttemptRecord]) -> Dict[str, int]:
+    summary = {
+        "total_exit_plan_attempts": 0,
+        "approved_native": 0,
+        "denied_native_with_reason": 0,
+        "denied_native_no_reason": 0,
+        "denied_native_with_freeform_reason": 0,
+        "denied_native_with_structured_reason": 0,
+        "denied_non_native_with_payload": 0,
+        "denied_non_native_no_payload": 0,
+        "captured_denial_reasons_total": 0,
+        "captured_freeform_reasons": 0,
+        "captured_structured_reasons": 0,
+        "human_reasons_total": 0,
+        "human_reasons_native": 0,
+        "human_reasons_non_native": 0,
+        "human_reasons_freeform": 0,
+        "human_reasons_structured": 0,
+        "non_native_other": 0,
+        "pending": 0,
+    }
+    for attempt in attempts:
+        summary["total_exit_plan_attempts"] += 1
+        summary[attempt.outcome] = summary.get(attempt.outcome, 0) + 1
+        if attempt.outcome == "denied_native_with_reason":
+            if attempt.native_reason_style == "freeform":
+                summary["denied_native_with_freeform_reason"] += 1
+            elif attempt.native_reason_style == "structured":
+                summary["denied_native_with_structured_reason"] += 1
+        if attempt.captured_reason:
+            summary["captured_denial_reasons_total"] += 1
+            if attempt.captured_reason_style == "freeform":
+                summary["captured_freeform_reasons"] += 1
+            elif attempt.captured_reason_style == "structured":
+                summary["captured_structured_reasons"] += 1
+        if attempt.human_reason:
+            summary["human_reasons_total"] += 1
+            if attempt.human_reason_source == "native_inline_reason":
+                summary["human_reasons_native"] += 1
+            else:
+                summary["human_reasons_non_native"] += 1
+            if attempt.human_reason_style == "freeform":
+                summary["human_reasons_freeform"] += 1
+            elif attempt.human_reason_style == "structured":
+                summary["human_reasons_structured"] += 1
+    return summary
+
+
+def filter_records(
+    attempts: List[AttemptRecord],
+    records_filter: str,
+) -> List[AttemptRecord]:
+    if records_filter == "all":
+        return attempts
+    if records_filter == "native":
+        return [
+            attempt
+            for attempt in attempts
+            if attempt.outcome.startswith("approved_native")
+            or attempt.outcome.startswith("denied_native")
+        ]
+    if records_filter == "native-denials":
+        return [
+            attempt
+            for attempt in attempts
+            if attempt.outcome.startswith("denied_native")
+        ]
+    if records_filter == "human-reasons":
+        return [attempt for attempt in attempts if attempt.human_reason]
+    return [
+        attempt
+        for attempt in attempts
+        if attempt.outcome.startswith("denied_native")
+        or attempt.outcome.startswith("denied_non_native")
+    ]
+
+
+def build_json_chunks(
+    records: List[AttemptRecord],
+    max_output_tokens_per_file: int,
+) -> List[List[AttemptRecord]]:
+    if not records:
+        return [[]]
+
+    chunks: List[List[AttemptRecord]] = []
+    current_chunk: List[AttemptRecord] = []
+    current_tokens = 0
+
+    for record in records:
+        record_dict = asdict(record)
+        record_json = json.dumps(record_dict, ensure_ascii=False)
+        record_tokens = estimate_tokens(record_json)
+
+        if current_chunk and current_tokens + record_tokens > max_output_tokens_per_file:
+            chunks.append(current_chunk)
+            current_chunk = []
+            current_tokens = 0
+
+        current_chunk.append(record)
+        current_tokens += record_tokens
+
+    if current_chunk:
+        chunks.append(current_chunk)
+
+    return chunks
+
+
+def print_summary(
+    projects_dir: Path,
+    include_subagents: bool,
+    stats: Dict[str, int],
+    attempts: List[AttemptRecord],
+    summary: Dict[str, int],
+    show_samples: int,
+    include_non_native_denials: bool,
+) -> None:
+    native_denials = (
+        summary["denied_native_with_reason"] + summary["denied_native_no_reason"]
+    )
+    total_denials = (
+        native_denials
+        + summary["denied_non_native_with_payload"]
+        + summary["denied_non_native_no_payload"]
+    )
+    native_extractable_ratio = (
+        (summary["denied_native_with_reason"] / native_denials) * 100.0
+        if native_denials
+        else 0.0
+    )
+    all_capture_ratio = (
+        (summary["captured_denial_reasons_total"] / total_denials) * 100.0
+        if total_denials
+        else 0.0
+    )
+
+    print(f"Projects dir: {projects_dir}")
+    print(f"Included subagents: {'yes' if include_subagents else 'no'}")
+    print(f"JSONL files scanned: {stats['files_scanned']}")
+    print(f"JSON lines scanned: {stats['lines_scanned']}")
+    print(f"JSON parse errors: {stats['json_errors']}")
+    print()
+    print(f"ExitPlanMode attempts: {summary['total_exit_plan_attempts']}")
+    print(f"Native approvals: {summary['approved_native']}")
+    print(
+        "Native denials with extractable reason: "
+        f"{summary['denied_native_with_reason']}"
+    )
+    print(
+        "Native denials without reason: "
+        f"{summary['denied_native_no_reason']}"
+    )
+    print(
+        "Freeform native reasons: "
+        f"{summary['denied_native_with_freeform_reason']}"
+    )
+    print(
+        "Structured native reasons: "
+        f"{summary['denied_native_with_structured_reason']}"
+    )
+    print(
+        "Non-native denials with payload: "
+        f"{summary['denied_non_native_with_payload']}"
+    )
+    print(
+        "Non-native denials without payload: "
+        f"{summary['denied_non_native_no_payload']}"
+    )
+    print(
+        "Captured denial reasons total: "
+        f"{summary['captured_denial_reasons_total']}"
+    )
+    print(
+        "Captured freeform reasons: "
+        f"{summary['captured_freeform_reasons']}"
+    )
+    print(
+        "Captured structured reasons: "
+        f"{summary['captured_structured_reasons']}"
+    )
+    print(f"Human reasons total: {summary['human_reasons_total']}")
+    print(f"Human reasons from native denials: {summary['human_reasons_native']}")
+    print(
+        "Human reasons from non-native denials: "
+        f"{summary['human_reasons_non_native']}"
+    )
+    print(
+        "Non-native / non-denial outcomes: "
+        f"{summary['non_native_other']}"
+    )
+    print(f"Pending / unmatched attempts: {summary['pending']}")
+    print()
+    print(
+        "Extractable native denial reasons: "
+        f"{summary['denied_native_with_reason']}/{native_denials} "
+        f"({native_extractable_ratio:.1f}%)"
+    )
+    print(
+        "Captured denial payloads across all denial types: "
+        f"{summary['captured_denial_reasons_total']}/{total_denials} "
+        f"({all_capture_ratio:.1f}%)"
+    )
+    print(
+        "Human reasons across all denial types: "
+        f"{summary['human_reasons_total']}/{total_denials} "
+        f"({((summary['human_reasons_total'] / total_denials) * 100.0 if total_denials else 0.0):.1f}%)"
+    )
+
+    if include_non_native_denials:
+        samples = [attempt for attempt in attempts if attempt.human_reason]
+    else:
+        samples = [
+            attempt
+            for attempt in attempts
+            if attempt.outcome == "denied_native_with_reason" and attempt.human_reason
+        ]
+    samples = samples[: max(show_samples, 0)]
+    if not samples:
+        return
+
+    print()
+    print(
+        "Sample denial reasons:"
+        if include_non_native_denials
+        else "Sample native denial reasons:"
+    )
+    for attempt in samples:
+        style = attempt.human_reason_style or "unknown"
+        source = attempt.human_reason_source or "unknown"
+        reason = attempt.human_reason or ""
+        print(
+            "- "
+            f"[{attempt.outcome} / {source} / {style}] "
+            f"{reason!r} "
+            f"({attempt.file_path}:{attempt.result_line_number})"
+        )
+
+
+def write_json_report(
+    output_path: Path,
+    projects_dir: Path,
+    include_subagents: bool,
+    stats: Dict[str, int],
+    summary: Dict[str, int],
+    records: List[AttemptRecord],
+    max_output_tokens_per_file: int,
+) -> List[Path]:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    chunks = build_json_chunks(records, max_output_tokens_per_file)
+    base_name = output_path.stem
+    output_dir = output_path.with_suffix("")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    written_files: List[Path] = []
+    part_summaries = []
+
+    for index, chunk in enumerate(chunks, start=1):
+        chunk_records = [asdict(record) for record in chunk]
+        chunk_payload = {
+            "projects_dir": str(projects_dir),
+            "include_subagents": include_subagents,
+            "stats": stats,
+            "summary": summary,
+            "part_index": index,
+            "part_count": len(chunks),
+            "record_count": len(chunk_records),
+            "records": chunk_records,
+        }
+        part_name = f"{base_name}.part-{index:04d}-of-{len(chunks):04d}.json"
+        part_path = output_dir / part_name
+        part_path.write_text(
+            json.dumps(chunk_payload, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+        written_files.append(part_path)
+        part_summaries.append(
+            {
+                "part_index": index,
+                "file_name": part_name,
+                "record_count": len(chunk_records),
+            }
+        )
+
+    manifest_payload = {
+        "projects_dir": str(projects_dir),
+        "include_subagents": include_subagents,
+        "stats": stats,
+        "summary": summary,
+        "records_filter_record_count": len(records),
+        "part_count": len(chunks),
+        "max_output_tokens_per_file": max_output_tokens_per_file,
+        "parts": part_summaries,
+    }
+    manifest_path = output_dir / f"{base_name}.manifest.json"
+    manifest_path.write_text(
+        json.dumps(manifest_payload, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    written_files.insert(0, manifest_path)
+
+    return written_files
+
+
+def main() -> int:
+    args = parse_args()
+    projects_dir = Path(args.projects_dir).expanduser()
+    if not projects_dir.exists():
+        print(f"Projects dir does not exist: {projects_dir}", file=sys.stderr)
+        return 1
+
+    stats, attempts = scan_projects(
+        projects_dir=projects_dir,
+        include_subagents=args.include_subagents,
+    )
+    attempts.sort(
+        key=lambda attempt: (
+            attempt.file_path,
+            attempt.line_number,
+            attempt.tool_use_id,
+        )
+    )
+    summary = summarize(attempts)
+    records = filter_records(attempts, args.records_filter)
+
+    print_summary(
+        projects_dir=projects_dir,
+        include_subagents=args.include_subagents,
+        stats=stats,
+        attempts=attempts,
+        summary=summary,
+        show_samples=args.show_samples,
+        include_non_native_denials=args.include_non_native_denials,
+    )
+
+    if args.json_out:
+        written_files = write_json_report(
+            output_path=Path(args.json_out).expanduser(),
+            projects_dir=projects_dir,
+            include_subagents=args.include_subagents,
+            stats=stats,
+            summary=summary,
+            records=records,
+            max_output_tokens_per_file=args.max_output_tokens_per_file,
+        )
+        part_count = max(len(written_files) - 1, 0)
+        print()
+        print(
+            "Wrote JSON output: "
+            f"detected {len(records)} records for filter '{args.records_filter}' "
+            f"and emitted {part_count} part file(s) plus a manifest."
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/claude/skills/plannotator-setup-goal/SKILL.md
+++ b/claude/skills/plannotator-setup-goal/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: plannotator-setup-goal
+disable-model-invocation: true
+description: Turn an idea or objective into a goal package for /goal. Interviews the user, builds a reviewed fact sheet via Plannotator, then explores the codebase to produce an execution plan.
+---
+
+# Setup Goal
+
+Turn an idea into a goal package at `goals/<slug>/` through structured discovery, user interview, and codebase exploration.
+
+## Phases
+
+### 1. Rearticulate
+
+State back what the user wants in your own words. If the conversation already has rich context, summarize it. If the goal is bare or vague, do minimal shallow exploration of the codebase to ground your understanding. Keep it to 2-3 sentences. Wait for the user to confirm or correct before continuing.
+
+Create the goal directory once the slug is clear:
+
+```bash
+mkdir -p goals/<slug>
+```
+
+Use `goals/<slug>/` for both working JSON files and final docs. The JSON files are provenance and iteration state; the markdown files are the human-readable authoritative goal package.
+
+**Browser session patience rule:** Plannotator goal setup is a user-driven browser session. After launching an interview or facts command, be absolutely patient and keep waiting on the user until they submit, dismiss, or explicitly ask you to stop. Do not close, kill, restart, refresh, or open a second copy just because the UI is idle or the user is taking time. Never close and reopen the session as a way to update state; if a rerun is needed after the prior session ends, update the working JSON file and launch a new command from that file.
+
+**Optional: grill first (deep, one-at-a-time interview).** Before building the compact interview bundle, *suggest* a grilling pass whenever the goal is vague or carries many interdependent decisions — and run one whenever the user asks for it ("grill me first"). This is opt-in: for a clear, well-scoped goal, skip it and go straight to the bundle, so grilling never fights the bundle's "fewer, higher-leverage questions" philosophy. When you grill, run the protocol below verbatim, then fold the resolved decisions forward into a higher-quality interview bundle (Phase 2) — or, if grilling fully resolves scope, straight into the fact sheet (Phase 3).
+
+<!-- Grilling protocol below adapted verbatim from the /grill-me skill by Matt Pocock (MIT-licensed):
+     https://github.com/mattpocock/skills/blob/main/skills/productivity/grill-me/SKILL.md -->
+
+> Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+>
+> Ask the questions one at a time.
+>
+> If a question can be answered by exploring the codebase, explore the codebase instead.
+
+### 2. Interview Bundle
+
+Build a compact bundle of questions that can derive every "fact" this goal should produce. Package the questions together so the user can answer them quickly in the Plannotator goal setup UI. For each question, include your recommended answer and use options when they make answering faster.
+
+Do not ask obvious confirmation questions. If the answer can be inferred from the user's request, from the conversation, or from shallow codebase exploration, infer it and move on. If an obvious area has meaningful nuance, present the inferred answer as a recommendation with options or a custom "add/correct this" path rather than asking the user to restate the obvious.
+
+Question areas that usually matter:
+
+- What the feature/change is
+- Who it's for
+- What problem it solves
+- What behavior changes
+- What success looks like
+- What's in and out of scope (the most important area to determine facts)
+- What edge cases to consider
+- What constraints or precedent apply
+
+**If a question can be answered by exploring the codebase, explore the codebase instead of asking.** Only include questions where the user's judgment is actually needed. Prefer fewer, higher-leverage questions over exhaustive obvious ones.
+
+Write the interview bundle before showing it to the user:
+
+`goals/<slug>/interview.json`
+
+```json
+{
+  "stage": "interview",
+  "title": "Short human-readable title",
+  "goalSlug": "<slug>",
+  "questions": [
+    {
+      "id": "scope",
+      "prompt": "What should be in scope?",
+      "description": "Optional clarification.",
+      "answerMode": "multi-custom",
+      "recommendedAnswer": "Your recommended answer.",
+      "recommendedOptionIds": ["ui", "server"],
+      "options": [
+        { "id": "ui", "label": "UI" },
+        { "id": "server", "label": "Server" }
+      ],
+      "required": true
+    }
+  ]
+}
+```
+
+Supported `answerMode` values: `text`, `single`, `multi`, `custom`, `single-custom`, `multi-custom`.
+
+Run this as a monitored foreground process and wait patiently for the browser session to finish. The command may appear idle while the user is reading, editing, or asking questions; leave it running:
+
+```bash
+plannotator setup-goal interview goals/<slug>/interview.json --json
+```
+
+The command returns JSON on stdout with the submitted answers. Write that exact result to `goals/<slug>/interview-result.json` before continuing. A convenient pattern is:
+
+```bash
+plannotator setup-goal interview goals/<slug>/interview.json --json | tee goals/<slug>/interview-result.json
+```
+
+If the user revises after the session finishes, update `interview.json` and rerun the command instead of reconstructing the whole bundle from memory. If the session is dismissed, stop and tell the user the goal setup was closed.
+
+Before moving to facts, read every answer and note carefully:
+
+- If the user wrote questions, uncertainty, "not sure", "needs context", or similar concerns in an answer or note, stop and address those questions in chat. Do not proceed to facts until the user has enough context or you have rerun a revised interview bundle.
+- If the user skipped a question with a note, treat the note as intentional feedback, not as an empty answer. Answer the note, refine the question, or make a documented assumption before proceeding.
+- If the user skipped a question without a note, proceed only if the missing answer is non-blocking; otherwise ask the smallest possible follow-up in chat.
+
+### 3. Fact Sheet
+
+A fact is a simple description of each outcome of a goal. It should be easily testable and verifiable. A fact may describe the function of a specific feature or aspect of a system. A fact may determine specific UI and UX. Again, a fact is literally anything that can be tested and verified in automated or manual testing. Keep fact language simple. In a way, a fact sheet is a design spec, but less verbose & using language the human user can easily visualize & rationalize. 
+
+Prepare a facts review bundle from `goals/<slug>/interview-result.json`. Each fact should include whether automated verification is recommended and preselected.
+
+Write the facts review bundle before showing it to the user. If revising after a prior facts pass, start from `facts-review.json` and `facts-result.json`, include previously accepted facts with `"accepted": true`, and preserve their state.
+
+`goals/<slug>/facts-review.json`
+
+```json
+{
+  "stage": "facts",
+  "title": "Short human-readable title",
+  "goalSlug": "<slug>",
+  "facts": [
+    {
+      "id": "fact-1",
+      "text": "The accepted fact text.",
+      "accepted": false,
+      "removed": false,
+      "recommendedAutomatedVerification": true,
+      "automatedVerification": true
+    }
+  ]
+}
+```
+
+Run this as a monitored foreground process and wait patiently for the browser session to finish. The command may appear idle while the user is reviewing, editing, or asking questions; leave it running:
+
+```bash
+plannotator setup-goal facts goals/<slug>/facts-review.json --json
+```
+
+The command returns JSON on stdout with accepted/edited/removed facts plus automated verification selections. Write that exact result to `goals/<slug>/facts-result.json`. A convenient pattern is:
+
+```bash
+plannotator setup-goal facts goals/<slug>/facts-review.json --json | tee goals/<slug>/facts-result.json
+```
+
+Write `goals/<slug>/facts.md` as a flat readable list of accepted facts. Each fact is one line; add a minimal note only when the fact cannot be stated clearly on its own. Also write `goals/<slug>/facts.meta.json` preserving each accepted fact's `id`, final `text`, `comment`, `recommendedAutomatedVerification`, and `automatedVerification` value.
+
+If the user edits or removes facts in the UI, apply that result directly. If the session is dismissed, stop and tell the user the facts review was closed.
+
+### 4. Plan
+
+Explore the codebase. Discover and validate implementation paths toward each accepted fact. Treat facts with `automatedVerification: true` as requiring concrete automated checks unless you document a blocker. Trace through code, identify files and systems involved, surface risks and unknowns. Refine until you have a confident order of operations.
+
+Write `goals/<slug>/plan.md`:
+
+- Solution approach (brief)
+- Ordered steps with the files/systems each touches
+- Verification for each step (concrete commands or checks)
+- Risks or open questions worth flagging
+
+Gate the plan with Plannotator:
+
+```bash
+plannotator annotate goals/<slug>/plan.md --gate
+```
+
+If denied, revise from feedback and re-gate until approved.
+
+### 5. Goal Output
+
+Write `goals/<slug>/goal.md`:
+
+- The articulated goal (1-3 sentences)
+- Reference to `facts.md` as the shared understanding
+- Reference to `plan.md` as the execution plan
+- Done condition
+
+Tell the user:
+
+```
+Done! Launch a goal with `/goal goals/<slug>/goal.md`
+```

--- a/claude/skills/plannotator-setup-goal/SKILL.test.ts
+++ b/claude/skills/plannotator-setup-goal/SKILL.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const skill = readFileSync(join(import.meta.dir, "SKILL.md"), "utf-8");
+
+describe("plannotator-setup-goal skill", () => {
+  test("uses bundled goal setup UI as the default interview path", () => {
+    expect(skill).toContain("Build a compact bundle of questions");
+    expect(skill).toContain("plannotator setup-goal interview");
+    expect(skill).toContain("goals/<slug>/interview.json");
+    expect(skill).toContain("goals/<slug>/interview-result.json");
+    expect(skill).toContain("Do not ask obvious confirmation questions");
+    expect(skill).toContain("Before moving to facts, read every answer and note carefully");
+    expect(skill).toContain("be absolutely patient and keep waiting on the user");
+    expect(skill).toContain("Do not close, kill, restart, refresh, or open a second copy");
+    expect(skill).not.toContain("setup-goal interview -");
+  });
+
+  test("allows opt-in grill-first questions before the bundled interview", () => {
+    const grillStart = skill.indexOf("**Optional: grill first");
+    const bundleStart = skill.indexOf("### 2. Interview Bundle");
+    expect(grillStart).toBeGreaterThan(-1);
+    expect(bundleStart).toBeGreaterThan(grillStart);
+
+    const grillSection = skill.slice(grillStart, bundleStart);
+    expect(grillSection).toContain("This is opt-in");
+    expect(grillSection).toContain("Ask the questions one at a time.");
+    expect(grillSection).toContain("If a question can be answered by exploring the codebase");
+  });
+
+  test("facts phase captures automated verification selections", () => {
+    expect(skill).toContain("plannotator setup-goal facts");
+    expect(skill).toContain("goals/<slug>/facts-review.json");
+    expect(skill).toContain("goals/<slug>/facts-result.json");
+    expect(skill).toContain("facts.meta.json");
+    expect(skill).toContain("automatedVerification");
+    expect(skill).not.toContain("setup-goal facts -");
+  });
+});

--- a/claude/skills/plannotator-setup-goal/agents/openai.yaml
+++ b/claude/skills/plannotator-setup-goal/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Setup Goal"
+  short_description: "Turn an idea into a goal package for /goal"
+  default_prompt: "Use $plannotator-setup-goal to turn this idea into a goal package."

--- a/claude/skills/plannotator-visual-explainer/SKILL.md
+++ b/claude/skills/plannotator-visual-explainer/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: plannotator-visual-explainer
+disable-model-invocation: true
+description: >
+  Generate self-contained HTML visualizations with Plannotator theming. Use for implementation
+  plans, PR explainers, architecture diagrams, data tables, slide decks, and any visual
+  explanation of technical concepts. Plans and PR explainers follow Plannotator's prescriptive
+  approach; all other visual content delegates to nicobailon/visual-explainer.
+---
+
+# Plannotator Visual Explainer
+
+Three paths depending on content type. Each has its own references and structure.
+
+## Route by content type
+
+**Implementation plan, design doc, or proposal** → Follow the [Plan path](#plan-path). Read `references/design-system.md` and `references/svg-patterns.md`. Prescriptive structure.
+
+**PR explainer, diff review, or code change walkthrough** → Follow the [PR path](#pr-path). Read `references/design-system.md` and `references/pr-components.md`. Prescriptive structure.
+
+**Everything else** (architecture diagrams, data tables, slide decks, project recaps, general visual explanations) → Follow the [Visual explainer path](#visual-explainer-path). Delegates to nicobailon/visual-explainer with Plannotator theme tokens.
+
+## Delivery
+
+Always deliver via Plannotator's annotation UI. Do NOT use `open` or `xdg-open`.
+
+**Plans/proposals** (user should approve/deny):
+```bash
+plannotator annotate <file> --gate
+```
+
+**Everything else** (informational):
+```bash
+plannotator annotate <file>
+```
+
+---
+
+## Plan path
+
+For implementation plans, design docs, feature specs, migration guides, and proposals.
+
+**Before generating, read:**
+1. `references/design-system.md` — Plannotator theme tokens, typography, component patterns
+2. `references/svg-patterns.md` — inline SVG building blocks for architecture diagrams, flowcharts, data flow
+
+**Document structure (in order, pick what fits):**
+
+1. **Header** — eyebrow label (mono, uppercase), title (serif, large), prompt box (the original brief)
+2. **Summary strip** — 3-5 stat cards showing key numbers at a glance (components, endpoints, tables, etc.)
+3. **Milestones / timeline** — vertical timeline showing phases without time estimates. Phases show sequence and dependencies, not duration.
+4. **Architecture / data flow** — inline SVG diagram. Use for 3+ interacting components. Highlighted boxes for new components, dashed arrows for async paths.
+5. **Mockups** — build UI mockups in HTML/CSS directly, not as descriptions
+6. **Key code** — dark-theme code blocks with syntax highlighting. Only architecturally significant interfaces/schemas — not every function.
+7. **Risks & mitigations** — table with severity badges (HIGH/MED/LOW)
+8. **Open questions** — callout cards with decision owner ("Decide with: backend team")
+
+Not every plan needs every section. Skip what doesn't serve the content. Never include time estimates, boilerplate sections, or exhaustive file lists.
+
+**Adapt to the task:** Backend → lead with data flow. Frontend → lead with mockups. Refactoring → lead with before/after diagrams. Infrastructure → lead with architecture.
+
+**Quality bar:** The plan answers "what, why, and how" within 30 seconds of reading. Whitespace is a feature — one idea per viewport.
+
+---
+
+## PR path
+
+For PR walkthroughs, diff reviews, code change explainers, and reviewer guides.
+
+**Before generating, read:**
+1. `references/design-system.md` — Plannotator theme tokens, typography, component patterns
+2. `references/pr-components.md` — diff rendering, review comment bubbles, risk chips, file cards, before/after panels
+
+**Document structure (in order, pick what fits):**
+
+1. **Header** — PR title, meta strip (file count, +/- lines, branch, author)
+2. **TL;DR** — bordered card with primary accent left border. 2-3 sentences. Readers who see nothing else should get the gist.
+3. **Why** — motivation and before/after comparison (two-column grid)
+4. **File tour** — collapsible cards per file. Each has: file path + badge (NEW/MOD/DEL) + line stats, a "why" paragraph, and important diff hunks. High-risk files expanded, safe files collapsed.
+5. **Risk map** — visual chips showing which files need careful review vs. which are mechanical. Three tiers: attention (destructive), medium (warning), safe (success).
+6. **Where to focus** — numbered callout cards. Each names a file/function and describes the concern.
+7. **Test plan** — checkbox-style verification checklist
+8. **Rollout** (if applicable) — phased deployment with feature flags
+
+Use Pierre diffs via CDN for syntax-highlighted inline diffs — see `references/pr-components.md` for the pattern.
+
+---
+
+## Visual explainer path
+
+For architecture diagrams, data tables, slide decks, project recaps, comparisons, and any other visual explanation.
+
+**Before generating:**
+
+1. Ensure `visual-explainer` is installed:
+   - Check: `~/.claude/skills/visual-explainer/SKILL.md` or `~/.agents/skills/visual-explainer/SKILL.md`
+   - If not found: `npx skills add nicobailon/visual-explainer -g --yes`
+2. Read visual-explainer's `SKILL.md` (workflow, diagram types, anti-slop rules)
+3. Read the relevant visual-explainer references and templates for your content type
+4. Read `references/theme-override.md` — Plannotator tokens replacing Nico's palettes
+
+Follow visual-explainer's structure, component classes (`.ve-card`, `.kpi-card`, `.pipeline`), and anti-slop rules. The only override is the color/typography layer — Plannotator tokens instead of Nico's custom palettes.
+
+---
+
+## Design philosophy (all paths)
+
+- **Whitespace is a feature.** Generous padding, large section gaps. If cramped, add space — don't shrink text.
+- **One idea per viewport.** Hero section, then diagram, then detail grid — not all crammed together.
+- **Show, don't describe.** A timeline shows sequencing. A diagram shows relationships. A code block shows the interface.
+- **No time estimates.** Timelines show phases and dependencies. Never attach hour/day estimates.

--- a/claude/skills/plannotator-visual-explainer/references/design-system.md
+++ b/claude/skills/plannotator-visual-explainer/references/design-system.md
@@ -1,0 +1,560 @@
+# Design System Reference
+
+Plan documents use Plannotator's semantic theme tokens. This makes them theme-aware: standalone files render with bundled defaults; embedded in the Plannotator UI, they inherit whatever theme is active (30+ themes, light and dark variants).
+
+## Standalone defaults
+
+Include this `:root` block so the plan works when opened directly in a browser. These are the Plannotator light theme values — they get overridden when embedded.
+
+```css
+:root {
+  --background: oklch(0.97 0.005 260);
+  --foreground: oklch(0.18 0.02 260);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.18 0.02 260);
+  --primary: oklch(0.50 0.25 280);
+  --primary-foreground: oklch(1 0 0);
+  --secondary: oklch(0.50 0.18 180);
+  --secondary-foreground: oklch(1 0 0);
+  --muted: oklch(0.92 0.01 260);
+  --muted-foreground: oklch(0.40 0.02 260);
+  --accent: oklch(0.60 0.22 50);
+  --accent-foreground: oklch(0.18 0.02 260);
+  --destructive: oklch(0.50 0.25 25);
+  --destructive-foreground: oklch(1 0 0);
+  --success: oklch(0.45 0.20 150);
+  --success-foreground: oklch(1 0 0);
+  --warning: oklch(0.55 0.18 85);
+  --warning-foreground: oklch(0.18 0.02 260);
+  --border: oklch(0.88 0.01 260);
+  --input: oklch(0.92 0.01 260);
+  --ring: oklch(0.50 0.25 280);
+  --code-bg: oklch(0.92 0.01 260);
+
+  --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', ui-monospace, monospace;
+  --font-display: ui-serif, Georgia, 'Times New Roman', serif;
+  --radius: 0.625rem;
+}
+```
+
+`--font-display` is plan-specific — used for headings and titles to create visual contrast with the body. It's not part of the core Plannotator theme, so it won't be overridden when embedded (which is the desired behavior).
+
+## Token usage map
+
+| Role | Token | SVG equivalent |
+|------|-------|----------------|
+| Page background | `--background` | — |
+| Primary text | `--foreground` | `fill` on text |
+| Card / panel background | `--card` | `fill` on rects |
+| Subdued text, labels, captions | `--muted-foreground` | `fill` on labels |
+| Soft backgrounds, secondary fills | `--muted` | `fill` on secondary rects |
+| Primary accent (CTA, attention, keywords) | `--primary` | `stroke` / `fill` on highlighted elements |
+| Warm accent | `--accent` | — |
+| Positive / success | `--success` | `stroke` / `fill` on success paths |
+| Caution | `--warning` | `fill` on warning badges |
+| Error / destructive | `--destructive` | `stroke` / `fill` on error paths |
+| Borders, dividers | `--border` | `stroke` on box outlines |
+| Arrow strokes, diagram lines | `--muted-foreground` | `stroke` on connectors |
+| Code block background | `--code-bg` | — |
+| Body font | `--font-sans` | `font-family` on SVG body text |
+| Code / labels font | `--font-mono` | `font-family` on SVG labels |
+| Display / heading font | `--font-display` | `font-family` on SVG titles |
+
+## Base styles
+
+```css
+*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  font-family: var(--font-sans);
+  background: var(--background);
+  color: var(--foreground);
+  line-height: 1.65;
+  font-size: 15px;
+  -webkit-font-smoothing: antialiased;
+}
+
+.container {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 64px 24px;
+}
+```
+
+## Typography
+
+**Headings** — `var(--font-display)`, weight 500, `var(--foreground)`.
+- H1: `2rem` page title
+- H2: `1.4rem` section headers
+- H3: `1.15rem` subsection headers
+
+**Body** — `var(--font-sans)`, weight 400, `0.95rem`, line-height `1.65`. Max paragraph width `65ch`.
+
+**Labels & metadata** — `var(--font-mono)`, `0.7–0.8rem`, weight 500, uppercase, letter-spacing `0.06em`, `var(--muted-foreground)`.
+
+**Code** — `var(--font-mono)`, `0.85rem`, line-height `1.55`.
+
+## Component patterns
+
+### Page header
+
+```html
+<header>
+  <span class="eyebrow">Implementation plan · Project name</span>
+  <h1>Plan Title Goes Here</h1>
+  <div class="prompt-box">
+    <span class="prompt-label">Brief</span>
+    <p>The original task or problem statement that motivated this plan.</p>
+  </div>
+</header>
+```
+
+```css
+.eyebrow {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted-foreground);
+}
+
+header h1 {
+  font-family: var(--font-display);
+  font-size: 2rem;
+  font-weight: 500;
+  margin: 8px 0 24px;
+  line-height: 1.2;
+}
+
+.prompt-box {
+  background: var(--muted);
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px 24px;
+}
+
+.prompt-label {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted-foreground);
+  display: block;
+  margin-bottom: 4px;
+}
+
+.prompt-box p {
+  font-size: 0.92rem;
+  color: var(--muted-foreground);
+  line-height: 1.55;
+}
+```
+
+### Summary strip (stat cards)
+
+```html
+<div class="summary-strip">
+  <div class="stat-card">
+    <span class="stat-value">4</span>
+    <span class="stat-label">Components</span>
+  </div>
+  <!-- more cards -->
+</div>
+```
+
+```css
+.summary-strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 16px;
+  margin: 32px 0;
+}
+
+.stat-card {
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px 24px;
+  text-align: center;
+  background: var(--card);
+}
+
+.stat-value {
+  font-family: var(--font-display);
+  font-size: 1.8rem;
+  font-weight: 500;
+  display: block;
+  color: var(--foreground);
+}
+
+.stat-label {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted-foreground);
+  margin-top: 4px;
+  display: block;
+}
+```
+
+### Section header
+
+```html
+<section>
+  <div class="section-header">
+    <span class="section-number">01</span>
+    <h2>Solution Overview</h2>
+  </div>
+  <!-- content -->
+</section>
+```
+
+```css
+section { margin-top: 64px; }
+
+.section-header {
+  display: flex;
+  align-items: baseline;
+  gap: 16px;
+  margin-bottom: 24px;
+  padding-bottom: 8px;
+  border-bottom: 1.5px solid var(--border);
+}
+
+.section-number {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--primary);
+}
+
+.section-header h2 {
+  font-family: var(--font-display);
+  font-size: 1.4rem;
+  font-weight: 500;
+}
+```
+
+### Code block (dark theme)
+
+```html
+<div class="code-panel">
+  <span class="code-label">src/api/handler.ts</span>
+  <pre><code><span class="kw">interface</span> <span class="fn">PlanRequest</span> {
+  <span class="fn">title</span>: <span class="kw">string</span>;
+  <span class="fn">sections</span>: <span class="fn">Section</span>[];
+}</code></pre>
+</div>
+```
+
+```css
+.code-panel {
+  background: var(--code-bg);
+  border-radius: var(--radius);
+  padding: 24px;
+  overflow-x: auto;
+  margin: 16px 0;
+  border: 1.5px solid var(--border);
+}
+
+.code-label {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--muted-foreground);
+  display: block;
+  margin-bottom: 8px;
+}
+
+.code-panel pre {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  line-height: 1.55;
+  color: var(--foreground);
+}
+
+/* Syntax tokens — these use semantic roles, not fixed colors */
+.code-panel .kw  { color: var(--primary); }         /* keywords */
+.code-panel .fn  { color: var(--accent); }           /* identifiers, types */
+.code-panel .str { color: var(--success); }          /* strings */
+.code-panel .cm  { color: var(--muted-foreground); font-style: italic; } /* comments */
+.code-panel .num { color: var(--warning); }          /* numbers */
+```
+
+### Risk table
+
+```html
+<div class="risk-grid">
+  <div class="risk-row">
+    <div class="risk-name">Database migration on large table</div>
+    <div><span class="badge high">HIGH</span></div>
+    <div class="risk-mitigation">Run during off-peak with online DDL</div>
+  </div>
+  <!-- more rows -->
+</div>
+```
+
+```css
+.risk-grid {
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.risk-row {
+  display: grid;
+  grid-template-columns: 1fr auto 1.5fr;
+  gap: 24px;
+  padding: 16px 24px;
+  align-items: center;
+  border-bottom: 1px solid var(--border);
+}
+
+.risk-row:last-child { border-bottom: none; }
+.risk-name { font-weight: 500; }
+.risk-mitigation { font-size: 0.9rem; color: var(--muted-foreground); }
+
+.badge {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: calc(var(--radius) - 4px);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.badge.high {
+  background: color-mix(in oklab, var(--destructive) 15%, transparent);
+  color: var(--destructive);
+}
+.badge.med {
+  background: color-mix(in oklab, var(--warning) 15%, transparent);
+  color: var(--warning);
+}
+.badge.low {
+  background: color-mix(in oklab, var(--success) 15%, transparent);
+  color: var(--success);
+}
+```
+
+### Callout / open question
+
+```html
+<div class="callout">
+  <h3>Should we use WebSockets or SSE?</h3>
+  <p>SSE is simpler but unidirectional. WebSockets add infrastructure complexity.</p>
+  <span class="decide-with">Decide with: infrastructure team</span>
+</div>
+```
+
+```css
+.callout {
+  border-left: 3px solid var(--primary);
+  padding: 16px 24px;
+  margin: 16px 0;
+  background: var(--card);
+  border-radius: 0 var(--radius) var(--radius) 0;
+}
+
+.callout h3 {
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+  font-weight: 500;
+  margin-bottom: 4px;
+}
+
+.callout p {
+  font-size: 0.9rem;
+  color: var(--muted-foreground);
+  line-height: 1.55;
+}
+
+.decide-with {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--primary);
+  font-weight: 500;
+  display: block;
+  margin-top: 8px;
+}
+```
+
+### Tag chips
+
+```html
+<div class="tags">
+  <span class="tag">packages/server</span>
+  <span class="tag highlight">new endpoint</span>
+</div>
+```
+
+```css
+.tags { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 8px; }
+
+.tag {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  padding: 2px 8px;
+  border-radius: calc(var(--radius) - 4px);
+  background: var(--muted);
+  color: var(--muted-foreground);
+}
+
+.tag.highlight {
+  background: color-mix(in oklab, var(--primary) 12%, transparent);
+  color: var(--primary);
+}
+```
+
+### Diagram panel
+
+Wraps SVG diagrams in a bordered container:
+
+```html
+<div class="diagram-panel">
+  <svg viewBox="0 0 720 280" xmlns="http://www.w3.org/2000/svg" style="width:100%">
+    <!-- diagram content -->
+  </svg>
+  <span class="diagram-caption">Request flow through the API gateway</span>
+</div>
+```
+
+```css
+.diagram-panel {
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius);
+  padding: 24px;
+  margin: 24px 0;
+  background: var(--card);
+}
+
+.diagram-caption {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--muted-foreground);
+  display: block;
+  margin-top: 8px;
+  text-align: center;
+}
+```
+
+### Two-column grid
+
+```css
+.two-col {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+}
+
+@media (max-width: 720px) {
+  .two-col { grid-template-columns: 1fr; }
+}
+```
+
+### Collapsible details
+
+```html
+<details>
+  <summary>Implementation details</summary>
+  <div class="details-body"><!-- content --></div>
+</details>
+```
+
+```css
+details {
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius);
+  margin: 16px 0;
+}
+
+summary {
+  font-family: var(--font-sans);
+  font-weight: 500;
+  padding: 16px 24px;
+  cursor: pointer;
+  list-style: none;
+}
+
+summary::before {
+  content: '▸';
+  display: inline-block;
+  margin-right: 8px;
+  transition: transform 0.2s;
+}
+
+details[open] summary::before { transform: rotate(90deg); }
+
+.details-body { padding: 0 24px 24px; }
+```
+
+### Milestone timeline
+
+Vertical timeline showing phases without time estimates.
+
+```html
+<div class="milestones">
+  <div class="milestone">
+    <div class="when">Phase 1</div>
+    <div class="dot-col"><span class="dot done"></span><span class="line"></span></div>
+    <div class="body">
+      <h3>Foundation</h3>
+      <p>Set up core infrastructure and initial integrations.</p>
+      <div class="tags"><span class="tag">packages/server</span></div>
+    </div>
+  </div>
+</div>
+```
+
+```css
+.milestones { display: flex; flex-direction: column; gap: 0; }
+
+.milestone {
+  display: grid;
+  grid-template-columns: 120px 28px 1fr;
+  gap: 0 18px;
+}
+
+.milestone .when {
+  text-align: right;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--muted-foreground);
+  padding-top: 4px;
+}
+
+.milestone .dot-col { display: flex; flex-direction: column; align-items: center; }
+
+.milestone .dot {
+  width: 14px; height: 14px; border-radius: 50%;
+  background: var(--card);
+  border: 3px solid var(--primary);
+  flex-shrink: 0;
+}
+
+.milestone .dot.done { background: var(--success); border-color: var(--success); }
+
+.milestone .line { width: 2px; flex: 1; background: var(--border); margin: 4px 0; }
+.milestone:last-child .line { display: none; }
+
+.milestone .body { padding-bottom: 36px; }
+
+.milestone .body h3 {
+  font-family: var(--font-display);
+  font-size: 1.15rem;
+  font-weight: 500;
+  margin-bottom: 4px;
+}
+
+.milestone .body p {
+  font-size: 0.88rem;
+  color: var(--muted-foreground);
+  max-width: 620px;
+  margin-bottom: 10px;
+}
+```

--- a/claude/skills/plannotator-visual-explainer/references/pr-components.md
+++ b/claude/skills/plannotator-visual-explainer/references/pr-components.md
@@ -1,0 +1,717 @@
+# PR Component Patterns
+
+Component patterns specific to PR explainer documents. For the base design system (colors, typography, layout), see `../../plannotator-visual-plan/references/design-system.md`.
+
+## Table of Contents
+1. [PR Header](#pr-header)
+2. [TL;DR Box](#tldr-box)
+3. [Diff Rendering](#diff-rendering)
+4. [Review Comments](#review-comments)
+5. [Risk Map](#risk-map)
+6. [File Cards](#file-cards)
+7. [Before / After](#before--after)
+8. [Where to Focus](#where-to-focus)
+9. [Test Plan](#test-plan)
+10. [File Badges](#file-badges)
+
+## PR header
+
+```html
+<header>
+  <span class="eyebrow">Pull request · repo-name</span>
+  <h1>Add real-time notification system</h1>
+  <div class="pr-meta">
+    <span>6 files</span>
+    <span class="additions">+142</span>
+    <span class="deletions">-38</span>
+    <span>feature/notifications → main</span>
+  </div>
+</header>
+```
+
+```css
+.pr-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--muted-foreground);
+  margin-top: 8px;
+}
+
+.pr-meta .additions { color: var(--success); }
+.pr-meta .deletions { color: var(--destructive); }
+```
+
+## TL;DR box
+
+```html
+<div class="tldr">
+  <h3>TL;DR</h3>
+  <p>Adds WebSocket-based notifications with per-user channels. Messages fan out
+     from a new NotificationService through Redis pub/sub. Existing REST endpoints
+     are unchanged.</p>
+</div>
+```
+
+```css
+.tldr {
+  background: var(--card);
+  border: 1.5px solid var(--border);
+  border-left: 4px solid var(--primary);
+  border-radius: var(--radius);
+  padding: 20px 24px;
+  max-width: 760px;
+  margin: 24px 0;
+}
+
+.tldr h3 {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--primary);
+  margin-bottom: 8px;
+}
+
+.tldr p {
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: var(--muted-foreground);
+}
+```
+
+## Diff rendering
+
+Use Pierre diffs via CDN for syntax-highlighted, theme-aware diff rendering. Renders into shadow DOM (no style conflicts) with Shiki syntax highlighting.
+
+```html
+<script type="module">
+  import { getSingularPatch, registerDiffsComponent } from 'https://cdn.jsdelivr.net/npm/@pierre/diffs@1.1.21/+esm';
+  registerDiffsComponent();
+
+  const patch = `--- a/src/handler.ts
++++ b/src/handler.ts
+@@ -1,4 +1,6 @@
+ import { Router } from 'express';
++import { NotificationService } from './notifications';
+-import { legacyPoll } from './polling';`;
+
+  const container = document.querySelector('diffs-container');
+  container.fileDiff = getSingularPatch(patch);
+  container.options = {
+    themeType: window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light',
+    diffStyle: 'unified',
+    diffIndicators: 'bars',
+    lineDiffType: 'word-alt',
+    unsafeCSS: `
+      :host {
+        --diffs-bg: var(--background);
+        --diffs-fg: var(--foreground);
+        border-radius: var(--radius);
+        border: 1.5px solid var(--border);
+        overflow: hidden;
+      }
+    `,
+  };
+</script>
+<diffs-container></diffs-container>
+```
+
+For multiple diffs, create one `<diffs-container>` per file. Pierre handles syntax highlighting, line numbers, add/del coloring, and word-level diffs automatically.
+
+## Review comments
+
+Speech bubbles with severity-coded left borders, attached below a diff block.
+
+```html
+<div class="comments">
+  <div class="bubble blocking">
+    <span class="anchor">line 11</span>
+    <span class="severity">BLOCKING</span>
+    <p>This mutation isn't wrapped in a transaction. If the second write
+       fails, the first persists — leaving the user in a broken state.</p>
+  </div>
+  <div class="bubble nit">
+    <span class="anchor">line 24</span>
+    <span class="severity">NIT</span>
+    <p>Prefer <code>const</code> here since <code>config</code> is never reassigned.</p>
+  </div>
+</div>
+```
+
+```css
+.comments {
+  padding: 18px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  background: var(--muted);
+  border-top: 1px solid var(--border);
+}
+
+.bubble {
+  position: relative;
+  background: var(--card);
+  border: 1.5px solid var(--border);
+  border-left-width: 4px;
+  border-radius: 8px;
+  padding: 12px 14px 12px 16px;
+  max-width: 680px;
+}
+
+.bubble.blocking { border-left-color: var(--primary); }
+.bubble.nit { border-left-color: var(--border); }
+.bubble.suggestion { border-left-color: var(--success); }
+
+.bubble::before {
+  content: "";
+  position: absolute;
+  left: -9px;
+  top: 16px;
+  width: 12px;
+  height: 12px;
+  background: var(--card);
+  border-left: 1.5px solid var(--border);
+  border-bottom: 1.5px solid var(--border);
+  transform: rotate(45deg);
+}
+
+.bubble.blocking::before {
+  border-left-color: var(--primary);
+  border-bottom-color: var(--primary);
+}
+
+.anchor {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: var(--muted-foreground);
+}
+
+.severity {
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-left: 8px;
+}
+
+.bubble.blocking .severity { color: var(--primary); }
+.bubble.nit .severity { color: var(--muted-foreground); }
+.bubble.suggestion .severity { color: var(--success); }
+
+.bubble p {
+  margin-top: 6px;
+  font-size: 0.88rem;
+  line-height: 1.55;
+  color: var(--foreground);
+}
+
+.bubble code {
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  background: var(--muted);
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+```
+
+## Risk map
+
+Chips that give a quick overview of file risk levels.
+
+```html
+<div class="risk-map">
+  <a href="#file-auth" class="chip attention">
+    <span class="dot"></span>
+    src/auth/middleware.ts
+  </a>
+  <a href="#file-db" class="chip medium">
+    <span class="dot"></span>
+    src/db/migrations/004.sql
+  </a>
+  <a href="#file-types" class="chip safe">
+    <span class="dot"></span>
+    src/types/index.ts
+  </a>
+</div>
+```
+
+```css
+.risk-map {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 24px 0;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  padding: 6px 12px;
+  border: 1.5px solid var(--border);
+  border-radius: 20px;
+  text-decoration: none;
+  color: var(--foreground);
+  transition: box-shadow 0.15s;
+}
+
+.chip:hover {
+  box-shadow: 0 0 0 2px color-mix(in oklab, var(--primary) 25%, transparent);
+}
+
+.chip .dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+}
+
+.chip.attention {
+  background: color-mix(in oklab, var(--destructive) 8%, transparent);
+  border-color: color-mix(in oklab, var(--destructive) 40%, transparent);
+}
+.chip.attention .dot { background: var(--destructive); }
+
+.chip.medium {
+  background: color-mix(in oklab, var(--warning) 10%, transparent);
+  border-color: color-mix(in oklab, var(--warning) 30%, transparent);
+}
+.chip.medium .dot { background: var(--warning); }
+
+.chip.safe {
+  background: color-mix(in oklab, var(--success) 8%, transparent);
+  border-color: color-mix(in oklab, var(--success) 35%, transparent);
+}
+.chip.safe .dot { background: var(--success); }
+```
+
+## File cards
+
+Expandable cards grouping a file's diff and review commentary.
+
+```html
+<div class="file-card" id="file-auth">
+  <div class="file-head">
+    <div class="file-info">
+      <span class="file-path">src/auth/middleware.ts</span>
+      <span class="file-badge mod">MOD</span>
+      <span class="file-stats"><span class="additions">+28</span> <span class="deletions">-12</span></span>
+    </div>
+    <span class="risk-tag attention">ATTENTION</span>
+  </div>
+  <div class="file-why">
+    <p>Replaced session-cookie auth with JWT verification. The trust boundary
+       moves from the session store to the token signature check.</p>
+  </div>
+  <div class="diff"><!-- diff rows --></div>
+  <div class="comments"><!-- review bubbles --></div>
+</div>
+
+<!-- Safe files: collapsed -->
+<details class="file-collapsed">
+  <summary>
+    <span class="file-path">src/types/index.ts</span>
+    <span class="file-badge mod">MOD</span>
+    <span class="file-stats"><span class="additions">+4</span> <span class="deletions">-0</span></span>
+    <span class="risk-tag safe">SAFE</span>
+  </summary>
+  <div class="file-why">
+    <p>Added NotificationPayload type export.</p>
+  </div>
+</details>
+```
+
+```css
+.file-card {
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--card);
+  overflow: hidden;
+  scroll-margin-top: 20px;
+  margin: 16px 0;
+}
+
+.file-head {
+  padding: 16px 20px;
+  border-bottom: 1.5px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.file-info {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.file-path {
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.file-stats {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+}
+
+.file-stats .additions { color: var(--success); }
+.file-stats .deletions { color: var(--destructive); }
+
+.file-why {
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--border);
+}
+
+.file-why p {
+  font-size: 0.9rem;
+  color: var(--muted-foreground);
+  line-height: 1.55;
+}
+
+/* Collapsed (safe) files */
+.file-collapsed {
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--card);
+  margin: 8px 0;
+}
+
+.file-collapsed summary {
+  list-style: none;
+  cursor: pointer;
+  padding: 14px 20px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.file-collapsed summary::after {
+  content: '+';
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: var(--muted-foreground);
+  margin-left: auto;
+}
+
+.file-collapsed[open] summary::after {
+  content: '\2212';
+}
+```
+
+## Before / after
+
+Two-column comparison grid.
+
+```html
+<div class="before-after">
+  <div class="ba-panel before">
+    <h4>Before</h4>
+    <p>Auth checked via session cookie on every request.
+       Session store hit adds ~15ms latency.</p>
+  </div>
+  <div class="ba-panel after">
+    <h4>After</h4>
+    <p>JWT signature verified in-process. No external store hit.
+       Latency drops to ~1ms per request.</p>
+  </div>
+</div>
+```
+
+```css
+.before-after {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin: 16px 0;
+}
+
+@media (max-width: 640px) {
+  .before-after { grid-template-columns: 1fr; }
+}
+
+.ba-panel {
+  background: var(--card);
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius);
+  padding: 18px 20px;
+}
+
+.ba-panel.after {
+  border-color: var(--success);
+}
+
+.ba-panel h4 {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 8px;
+}
+
+.ba-panel.before h4 { color: var(--muted-foreground); }
+.ba-panel.after h4 { color: var(--success); }
+
+.ba-panel p {
+  font-size: 0.9rem;
+  line-height: 1.55;
+  color: var(--foreground);
+}
+```
+
+## Where to focus
+
+Numbered callout cards directing reviewers.
+
+```html
+<div class="focus-list">
+  <div class="focus-item">
+    <span class="focus-number">1</span>
+    <div>
+      <strong>src/auth/middleware.ts:verifyToken()</strong>
+      <p>New trust boundary. Verify the JWT validation covers all edge cases:
+         expired tokens, malformed signatures, missing claims.</p>
+    </div>
+  </div>
+</div>
+```
+
+```css
+.focus-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin: 16px 0;
+}
+
+.focus-item {
+  background: var(--card);
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px 20px;
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.focus-number {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--primary-foreground);
+  background: var(--primary);
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.focus-item strong {
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  display: block;
+  margin-bottom: 4px;
+}
+
+.focus-item p {
+  font-size: 0.88rem;
+  color: var(--muted-foreground);
+  line-height: 1.5;
+}
+```
+
+## Test plan
+
+Checkbox-style verification checklist.
+
+```html
+<div class="test-list">
+  <div class="test-item done">
+    <span class="check"></span>
+    <span>Expired JWT returns 401 with proper error body</span>
+  </div>
+  <div class="test-item">
+    <span class="check"></span>
+    <span>Concurrent WebSocket connections scale to 1000 without memory leak</span>
+  </div>
+</div>
+```
+
+```css
+.test-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 16px 0;
+}
+
+.test-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  background: var(--card);
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius);
+  padding: 13px 18px;
+  font-size: 0.88rem;
+}
+
+.check {
+  width: 18px;
+  height: 18px;
+  border-radius: 5px;
+  border: 1.5px solid var(--border);
+  flex-shrink: 0;
+  position: relative;
+  margin-top: 2px;
+}
+
+.test-item.done .check {
+  background: var(--success);
+  border-color: var(--success);
+}
+
+.test-item.done .check::after {
+  content: '';
+  position: absolute;
+  left: 5px;
+  top: 2px;
+  width: 5px;
+  height: 9px;
+  border-right: 2px solid var(--card);
+  border-bottom: 2px solid var(--card);
+  transform: rotate(40deg);
+}
+```
+
+## File badges
+
+```css
+.file-badge {
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 6px;
+  border-radius: calc(var(--radius) - 4px);
+}
+
+.file-badge.new {
+  background: color-mix(in oklab, var(--success) 15%, transparent);
+  color: var(--success);
+}
+
+.file-badge.mod {
+  background: color-mix(in oklab, var(--warning) 15%, transparent);
+  color: var(--warning);
+}
+
+.file-badge.del {
+  background: color-mix(in oklab, var(--destructive) 15%, transparent);
+  color: var(--destructive);
+}
+
+.risk-tag {
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 3px 8px;
+  border-radius: calc(var(--radius) - 4px);
+}
+
+.risk-tag.attention {
+  background: color-mix(in oklab, var(--destructive) 12%, transparent);
+  color: var(--destructive);
+}
+
+.risk-tag.medium {
+  background: color-mix(in oklab, var(--warning) 12%, transparent);
+  color: var(--warning);
+}
+
+.risk-tag.safe {
+  background: color-mix(in oklab, var(--success) 12%, transparent);
+  color: var(--success);
+}
+```
+
+## Rollout plan
+
+Phased deployment strip showing ramp percentages.
+
+```html
+<div class="rollout">
+  <div class="rollout-step">
+    <div class="rollout-when">Day 0</div>
+    <div class="rollout-pct">internal</div>
+    <div class="rollout-desc">Team only. Watch error rates.</div>
+  </div>
+  <div class="rollout-step">
+    <div class="rollout-when">Day 2</div>
+    <div class="rollout-pct">10%</div>
+    <div class="rollout-desc">Random sample. Alert on anomalies.</div>
+  </div>
+  <div class="rollout-step">
+    <div class="rollout-when">Day 4</div>
+    <div class="rollout-pct">100%</div>
+    <div class="rollout-desc">Full ramp.</div>
+  </div>
+</div>
+```
+
+```css
+.rollout { display: flex; gap: 0; }
+
+.rollout-step {
+  flex: 1;
+  background: var(--card);
+  border: 1.5px solid var(--border);
+  padding: 16px 18px;
+}
+
+.rollout-step:first-child { border-radius: var(--radius) 0 0 var(--radius); }
+.rollout-step:last-child { border-radius: 0 var(--radius) var(--radius) 0; }
+.rollout-step + .rollout-step { border-left: none; }
+
+.rollout-when {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted-foreground);
+  margin-bottom: 8px;
+}
+
+.rollout-pct {
+  font-family: var(--font-mono);
+  font-size: 1.35rem;
+  font-weight: 600;
+  color: var(--primary);
+  margin-bottom: 6px;
+}
+
+.rollout-desc {
+  font-size: 0.82rem;
+  color: var(--muted-foreground);
+}
+
+@media (max-width: 720px) {
+  .rollout { flex-direction: column; }
+  .rollout-step { border-radius: var(--radius); }
+  .rollout-step + .rollout-step { border-left: 1.5px solid var(--border); margin-top: 10px; }
+}
+```

--- a/claude/skills/plannotator-visual-explainer/references/svg-patterns.md
+++ b/claude/skills/plannotator-visual-explainer/references/svg-patterns.md
@@ -1,0 +1,368 @@
+# SVG Diagram Patterns
+
+Building blocks for creating diagrams in implementation plans. All SVGs are inline — no external dependencies. Compose these patterns to build architecture diagrams, data flow visualizations, flowcharts, and charts.
+
+All colors reference Plannotator theme tokens. In SVG, use the CSS custom property values directly via `style` attributes or the corresponding CSS classes.
+
+## Table of Contents
+1. [Arrow Markers](#arrow-markers)
+2. [Architecture Diagrams](#architecture-diagrams)
+3. [Flowcharts](#flowcharts)
+4. [Data Flow](#data-flow)
+5. [Bar Charts](#bar-charts)
+6. [Positioning & Layout](#positioning--layout)
+
+## Arrow markers
+
+Define reusable markers in `<defs>`. Reference them via `marker-end="url(#arrow)"`.
+
+```svg
+<defs>
+  <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5"
+          markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+    <path d="M0,0 L10,5 L0,10 z" fill="var(--muted-foreground)"/>
+  </marker>
+
+  <marker id="arrow-primary" viewBox="0 0 10 10" refX="9" refY="5"
+          markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+    <path d="M0,0 L10,5 L0,10 z" fill="var(--primary)"/>
+  </marker>
+
+  <marker id="arrow-success" viewBox="0 0 10 10" refX="9" refY="5"
+          markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+    <path d="M0,0 L10,5 L0,10 z" fill="var(--success)"/>
+  </marker>
+
+  <marker id="arrow-destructive" viewBox="0 0 10 10" refX="9" refY="5"
+          markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+    <path d="M0,0 L10,5 L0,10 z" fill="var(--destructive)"/>
+  </marker>
+</defs>
+```
+
+**Note on CSS vars in SVG:** `fill="var(--primary)"` works in inline SVG within an HTML document. For broader compatibility, you can also style via CSS classes instead of inline attributes.
+
+## Architecture diagrams
+
+Box-and-arrow diagrams showing how components connect.
+
+### Box node
+
+```svg
+<g transform="translate(100, 80)">
+  <rect width="140" height="56" rx="10" fill="var(--card)"
+        stroke="var(--border)" stroke-width="1.5"/>
+  <text x="70" y="24" text-anchor="middle"
+        font-family="var(--font-sans)" font-size="13" font-weight="600"
+        fill="var(--foreground)">API Server</text>
+  <text x="70" y="40" text-anchor="middle"
+        font-family="var(--font-mono)" font-size="10.5"
+        fill="var(--muted-foreground)">Express + middleware</text>
+</g>
+```
+
+### Highlighted box (new or hot-path component)
+
+```svg
+<g transform="translate(100, 80)">
+  <rect width="140" height="56" rx="10"
+        fill="color-mix(in oklab, var(--primary) 8%, transparent)"
+        stroke="var(--primary)" stroke-width="1.5"/>
+  <text x="70" y="24" text-anchor="middle"
+        font-family="var(--font-sans)" font-size="13" font-weight="600"
+        fill="var(--foreground)">New Service</text>
+  <text x="70" y="40" text-anchor="middle"
+        font-family="var(--font-mono)" font-size="10.5"
+        fill="var(--primary)">to be created</text>
+</g>
+```
+
+### Connecting arrows
+
+```svg
+<!-- Horizontal -->
+<line x1="240" y1="108" x2="320" y2="108"
+      stroke="var(--muted-foreground)" stroke-width="1.5"
+      marker-end="url(#arrow)"/>
+
+<!-- Vertical -->
+<line x1="170" y1="136" x2="170" y2="200"
+      stroke="var(--muted-foreground)" stroke-width="1.5"
+      marker-end="url(#arrow)"/>
+
+<!-- Dashed (async, optional, or secondary) -->
+<line x1="240" y1="108" x2="320" y2="108"
+      stroke="var(--primary)" stroke-width="1.5"
+      stroke-dasharray="5 4"
+      marker-end="url(#arrow-primary)"/>
+```
+
+### Edge labels
+
+Place at the midpoint of an arrow, offset above:
+
+```svg
+<text x="280" y="100" text-anchor="middle"
+      font-family="var(--font-mono)" font-size="9.5"
+      fill="var(--muted-foreground)">REST</text>
+```
+
+### Full architecture example
+
+```svg
+<svg viewBox="0 0 720 280" xmlns="http://www.w3.org/2000/svg"
+     style="width:100%;max-width:720px">
+  <style>
+    .box { fill: var(--card); stroke: var(--border); stroke-width: 1.5; }
+    .box-new { fill: color-mix(in oklab, var(--primary) 8%, transparent);
+               stroke: var(--primary); stroke-width: 1.5; }
+    .label { font-family: var(--font-sans); font-size: 13px;
+             font-weight: 600; fill: var(--foreground); }
+    .sublabel { font-family: var(--font-mono); font-size: 10.5px;
+                fill: var(--muted-foreground); }
+    .edge { stroke: var(--muted-foreground); stroke-width: 1.5; }
+    .edge-label { font-family: var(--font-mono); font-size: 9.5px;
+                  fill: var(--muted-foreground); }
+  </style>
+  <defs>
+    <marker id="a" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="var(--muted-foreground)"/>
+    </marker>
+  </defs>
+
+  <!-- Browser -->
+  <rect x="20" y="100" width="120" height="56" rx="10" class="box"/>
+  <text x="80" y="124" text-anchor="middle" class="label">Browser</text>
+  <text x="80" y="140" text-anchor="middle" class="sublabel">React SPA</text>
+
+  <!-- Arrow: Browser → API -->
+  <line x1="140" y1="128" x2="220" y2="128" class="edge" marker-end="url(#a)"/>
+  <text x="180" y="120" text-anchor="middle" class="edge-label">HTTPS</text>
+
+  <!-- API Gateway (new) -->
+  <rect x="220" y="100" width="140" height="56" rx="10" class="box-new"/>
+  <text x="290" y="124" text-anchor="middle" class="label">API Gateway</text>
+  <text x="290" y="140" text-anchor="middle" class="sublabel"
+        fill="var(--primary)">new</text>
+
+  <!-- Arrow: API → DB -->
+  <line x1="360" y1="128" x2="440" y2="128" class="edge" marker-end="url(#a)"/>
+
+  <!-- Postgres -->
+  <rect x="440" y="100" width="120" height="56" rx="10" class="box"/>
+  <text x="500" y="124" text-anchor="middle" class="label">Postgres</text>
+  <text x="500" y="140" text-anchor="middle" class="sublabel">existing</text>
+
+  <!-- Arrow: API → Cache (vertical) -->
+  <line x1="290" y1="156" x2="290" y2="210" class="edge" marker-end="url(#a)"/>
+
+  <!-- Redis -->
+  <rect x="220" y="210" width="140" height="48" rx="10" class="box"/>
+  <text x="290" y="240" text-anchor="middle" class="label">Redis Cache</text>
+</svg>
+```
+
+## Flowcharts
+
+### Process box
+
+```svg
+<rect x="250" y="80" width="120" height="40" rx="8"
+      fill="var(--card)" stroke="var(--border)" stroke-width="1.5"/>
+<text x="310" y="105" text-anchor="middle"
+      font-family="var(--font-sans)" font-size="12" font-weight="500"
+      fill="var(--foreground)">Parse input</text>
+```
+
+### Decision diamond
+
+```svg
+<path d="M310,262 L352,294 L310,326 L268,294 Z"
+      fill="var(--card)" stroke="var(--border)" stroke-width="1.5"/>
+<text x="310" y="298" text-anchor="middle"
+      font-family="var(--font-sans)" font-size="11" font-weight="500"
+      fill="var(--foreground)">Valid?</text>
+```
+
+### Terminal / pill node
+
+```svg
+<rect x="260" y="20" width="100" height="36" rx="18"
+      fill="var(--card)" stroke="var(--border)" stroke-width="1.5"/>
+<text x="310" y="43" text-anchor="middle"
+      font-family="var(--font-sans)" font-size="12" font-weight="500"
+      fill="var(--foreground)">Start</text>
+```
+
+### Success / failure endpoints
+
+```svg
+<!-- Success -->
+<rect x="260" y="400" width="100" height="36" rx="18"
+      fill="color-mix(in oklab, var(--success) 12%, transparent)"
+      stroke="var(--success)" stroke-width="1.5"/>
+<text x="310" y="423" text-anchor="middle"
+      font-family="var(--font-sans)" font-size="12" font-weight="600"
+      fill="var(--success)">Done</text>
+
+<!-- Failure -->
+<rect x="100" y="400" width="100" height="36" rx="18"
+      fill="color-mix(in oklab, var(--destructive) 12%, transparent)"
+      stroke="var(--destructive)" stroke-width="1.5"/>
+<text x="150" y="423" text-anchor="middle"
+      font-family="var(--font-sans)" font-size="12" font-weight="600"
+      fill="var(--destructive)">Error</text>
+```
+
+### Curved branch path
+
+For routing flow from a decision to a side branch:
+
+```svg
+<path d="M268,294 C200,294 160,294 160,240"
+      fill="none" stroke="var(--destructive)" stroke-width="1.5"
+      marker-end="url(#arrow-destructive)"/>
+```
+
+## Data flow
+
+### Request / response pair
+
+```svg
+<!-- Request (solid) -->
+<line x1="140" y1="100" x2="280" y2="100"
+      stroke="var(--muted-foreground)" stroke-width="1.5"
+      marker-end="url(#arrow)"/>
+<text x="210" y="92" text-anchor="middle"
+      font-family="var(--font-mono)" font-size="9.5"
+      fill="var(--muted-foreground)">POST /api/plan</text>
+
+<!-- Response (dashed) -->
+<line x1="280" y1="116" x2="140" y2="116"
+      stroke="var(--primary)" stroke-width="1.5" stroke-dasharray="5 4"
+      marker-end="url(#arrow-primary)"/>
+<text x="210" y="132" text-anchor="middle"
+      font-family="var(--font-mono)" font-size="9.5"
+      fill="var(--primary)">{ plan, status }</text>
+```
+
+### Fan-out pattern
+
+```svg
+<!-- Source box radiating to multiple targets -->
+<line x1="200" y1="100" x2="340" y2="60"
+      stroke="var(--muted-foreground)" stroke-width="1.5" marker-end="url(#arrow)"/>
+<line x1="200" y1="100" x2="340" y2="100"
+      stroke="var(--muted-foreground)" stroke-width="1.5" marker-end="url(#arrow)"/>
+<line x1="200" y1="100" x2="340" y2="140"
+      stroke="var(--muted-foreground)" stroke-width="1.5" marker-end="url(#arrow)"/>
+```
+
+## Bar charts
+
+```svg
+<svg viewBox="0 0 400 180" xmlns="http://www.w3.org/2000/svg"
+     style="width:100%;max-width:400px">
+  <!-- Gridlines -->
+  <line x1="40" y1="20" x2="380" y2="20"
+        stroke="var(--border)" stroke-width="1" opacity="0.5"/>
+  <line x1="40" y1="60" x2="380" y2="60"
+        stroke="var(--border)" stroke-width="1" opacity="0.5"/>
+  <line x1="40" y1="100" x2="380" y2="100"
+        stroke="var(--border)" stroke-width="1" opacity="0.5"/>
+  <line x1="40" y1="140" x2="380" y2="140"
+        stroke="var(--border)" stroke-width="1"/>
+
+  <!-- Y-axis labels -->
+  <text x="35" y="24" text-anchor="end"
+        font-family="var(--font-mono)" font-size="9"
+        fill="var(--muted-foreground)">30</text>
+  <text x="35" y="64" text-anchor="end"
+        font-family="var(--font-mono)" font-size="9"
+        fill="var(--muted-foreground)">20</text>
+  <text x="35" y="104" text-anchor="end"
+        font-family="var(--font-mono)" font-size="9"
+        fill="var(--muted-foreground)">10</text>
+
+  <!-- Bars (muted default, primary for peak) -->
+  <rect x="60" y="60" width="40" height="80" rx="4"
+        fill="var(--muted)"/>
+  <rect x="120" y="40" width="40" height="100" rx="4"
+        fill="var(--primary)"/>
+  <rect x="180" y="80" width="40" height="60" rx="4"
+        fill="var(--muted)"/>
+  <rect x="240" y="100" width="40" height="40" rx="4"
+        fill="var(--muted)"/>
+
+  <!-- Value labels -->
+  <text x="80" y="55" text-anchor="middle"
+        font-family="var(--font-mono)" font-size="10" font-weight="600"
+        fill="var(--foreground)">20</text>
+  <text x="140" y="35" text-anchor="middle"
+        font-family="var(--font-mono)" font-size="10" font-weight="600"
+        fill="var(--primary)">25</text>
+
+  <!-- X-axis labels -->
+  <text x="80" y="158" text-anchor="middle"
+        font-family="var(--font-mono)" font-size="9"
+        fill="var(--muted-foreground)">Q1</text>
+  <text x="140" y="158" text-anchor="middle"
+        font-family="var(--font-mono)" font-size="9"
+        fill="var(--muted-foreground)">Q2</text>
+  <text x="200" y="158" text-anchor="middle"
+        font-family="var(--font-mono)" font-size="9"
+        fill="var(--muted-foreground)">Q3</text>
+  <text x="260" y="158" text-anchor="middle"
+        font-family="var(--font-mono)" font-size="9"
+        fill="var(--muted-foreground)">Q4</text>
+</svg>
+```
+
+## Positioning & layout
+
+### SVG container sizing
+- Use `viewBox` with fixed coordinates; set `style="width:100%;max-width:NNNpx"` for responsive scaling
+- Standard widths: `720px` full-width, `480px` half-width, `360px` sidebar
+- Standard heights: `180–320px` for most diagrams
+
+### Box sizing
+- Standard node: `120–160px` wide, `48–56px` tall
+- Minimum gap between nodes: `60px` horizontal, `40px` vertical
+- Arrow label offset: `8–12px` above the line
+- Diagram padding: `20px` inside the viewBox edges
+
+### Color roles in diagrams
+
+| Element | Fill / stroke | Token |
+|---------|---------------|-------|
+| Box background | fill | `var(--card)` |
+| Box stroke | stroke | `var(--border)` |
+| Highlighted box bg | fill | `color-mix(in oklab, var(--primary) 8%, transparent)` |
+| Highlighted box stroke | stroke | `var(--primary)` |
+| Arrow / connector | stroke | `var(--muted-foreground)` |
+| Title text | fill | `var(--foreground)` |
+| Subtitle / label text | fill | `var(--muted-foreground)` |
+| Success path | stroke | `var(--success)` |
+| Error path | stroke | `var(--destructive)` |
+| Warning | fill | `var(--warning)` |
+
+### Using CSS classes in SVG
+
+For cleaner markup, define reusable classes in a `<style>` block inside the SVG:
+
+```svg
+<svg viewBox="0 0 720 280" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .box   { fill: var(--card); stroke: var(--border); stroke-width: 1.5; }
+    .new   { fill: color-mix(in oklab, var(--primary) 8%, transparent);
+             stroke: var(--primary); stroke-width: 1.5; }
+    .title { font-family: var(--font-sans); font-size: 13px;
+             font-weight: 600; fill: var(--foreground); }
+    .sub   { font-family: var(--font-mono); font-size: 10.5px;
+             fill: var(--muted-foreground); }
+    .conn  { stroke: var(--muted-foreground); stroke-width: 1.5; }
+  </style>
+  <!-- nodes and connectors use class="box", class="title", etc. -->
+</svg>
+```

--- a/claude/skills/plannotator-visual-explainer/references/theme-override.md
+++ b/claude/skills/plannotator-visual-explainer/references/theme-override.md
@@ -1,0 +1,162 @@
+# Plannotator Theme Override
+
+When visual-explainer's workflow says to pick a palette and font pairing, use these Plannotator tokens instead. Everything else — layout, structure, components, anti-slop rules — stays as visual-explainer prescribes.
+
+## CSS Custom Properties
+
+Replace visual-explainer's `--bg`, `--surface`, `--border`, `--text`, `--accent` variables with Plannotator's semantic tokens. Include these as `:root` defaults so the file works standalone. When embedded in Plannotator's raw HTML annotation mode, these get overridden by the active theme.
+
+```css
+:root {
+  /* Surfaces */
+  --background: oklch(0.97 0.005 260);
+  --foreground: oklch(0.18 0.02 260);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.18 0.02 260);
+  --muted: oklch(0.92 0.01 260);
+  --muted-foreground: oklch(0.40 0.02 260);
+
+  /* Accents */
+  --primary: oklch(0.50 0.25 280);
+  --primary-foreground: oklch(1 0 0);
+  --secondary: oklch(0.50 0.18 180);
+  --accent: oklch(0.60 0.22 50);
+  --accent-foreground: oklch(0.18 0.02 260);
+
+  /* Semantic */
+  --destructive: oklch(0.50 0.25 25);
+  --success: oklch(0.45 0.20 150);
+  --warning: oklch(0.55 0.18 85);
+
+  /* Structure */
+  --border: oklch(0.88 0.01 260);
+  --code-bg: oklch(0.92 0.01 260);
+  --ring: oklch(0.50 0.25 280);
+  --radius: 0.625rem;
+
+  /* Typography */
+  --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', ui-monospace, monospace;
+  --font-display: ui-serif, Georgia, 'Times New Roman', serif;
+}
+```
+
+## Mapping visual-explainer variables to Plannotator tokens
+
+When visual-explainer references or templates use these variables, substitute:
+
+| visual-explainer | Plannotator | Notes |
+|-----------------|-------------|-------|
+| `--bg` | `var(--background)` | Page background |
+| `--surface` | `var(--card)` | Card/panel surfaces |
+| `--border` | `var(--border)` | Borders and dividers |
+| `--text` | `var(--foreground)` | Primary text |
+| `--text-dim` | `var(--muted-foreground)` | Secondary/subdued text |
+| `--accent` (primary) | `var(--primary)` | Primary accent |
+| `--accent-dim` | `color-mix(in oklab, var(--primary) 15%, transparent)` | Accent backgrounds |
+| `--accent-2` | `var(--accent)` | Secondary accent (warm) |
+| `--accent-3` | `var(--secondary)` | Tertiary accent |
+| `--success` | `var(--success)` | Positive indicators |
+| `--warning` | `var(--warning)` | Caution indicators |
+| `--error` / `--danger` | `var(--destructive)` | Error/destructive indicators |
+| `--font-body` | `var(--font-sans)` | Body text font |
+| `--font-mono` | `var(--font-mono)` | Code and labels |
+| `--font-heading` | `var(--font-display)` | Headings (serif) |
+
+## Typography exception
+
+Visual-explainer forbids Inter as `--font-body`. Plannotator uses Inter as its default sans-serif. This is intentional — Plannotator's identity is defined by its theme tokens, not font novelty. When using this skill, Inter is permitted as the body font because the output is meant to look like part of Plannotator, not like an independent design piece.
+
+The `--font-display` (serif) is still used for headings to create visual contrast, matching the visual-explainer's emphasis on distinctive typography.
+
+## Mermaid theming
+
+When visual-explainer instructs you to set `themeVariables` in Mermaid config, use Plannotator tokens:
+
+```javascript
+mermaid.initialize({
+  theme: 'base',
+  themeVariables: {
+    primaryColor: 'oklch(0.50 0.25 280)',         // --primary
+    primaryTextColor: 'oklch(1 0 0)',              // --primary-foreground
+    primaryBorderColor: 'oklch(0.88 0.01 260)',    // --border
+    lineColor: 'oklch(0.40 0.02 260)',             // --muted-foreground
+    secondaryColor: 'oklch(0.92 0.01 260)',        // --muted
+    tertiaryColor: 'oklch(0.92 0.01 260)',         // --muted
+    fontFamily: "'Inter', system-ui, sans-serif",
+    fontSize: '14px',
+  }
+});
+```
+
+## Dark mode
+
+Plannotator handles dark/light via theme classes, not `prefers-color-scheme`. The standalone defaults above are the light theme. When embedded in raw HTML annotation mode, the active theme's tokens override automatically — no media query needed in the generated HTML.
+
+For standalone viewing, you may optionally add a `prefers-color-scheme: dark` block with the Plannotator dark theme values:
+
+```css
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: oklch(0.15 0.02 260);
+    --foreground: oklch(0.90 0.01 260);
+    --card: oklch(0.22 0.02 260);
+    --card-foreground: oklch(0.90 0.01 260);
+    --muted: oklch(0.26 0.02 260);
+    --muted-foreground: oklch(0.72 0.02 260);
+    --primary: oklch(0.75 0.18 280);
+    --primary-foreground: oklch(0.15 0.02 260);
+    --accent: oklch(0.70 0.20 60);
+    --border: oklch(0.35 0.02 260);
+    --code-bg: oklch(0.26 0.02 260);
+    --destructive: oklch(0.65 0.20 25);
+    --success: oklch(0.72 0.17 150);
+    --warning: oklch(0.75 0.15 85);
+  }
+}
+```
+
+## Depth tiers
+
+Visual-explainer defines depth tiers (hero, elevated, default, recessed). Map them using Plannotator tokens:
+
+```css
+/* Hero — elevated, accent-tinted */
+.ve-card--hero {
+  background: color-mix(in oklab, var(--primary) 5%, var(--card));
+  border-color: var(--primary);
+  box-shadow: 0 4px 24px color-mix(in oklab, var(--primary) 10%, transparent);
+}
+
+/* Default — standard card */
+.ve-card {
+  background: var(--card);
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius);
+}
+
+/* Recessed — subdued */
+.ve-card--recessed {
+  background: var(--muted);
+  border-color: transparent;
+}
+```
+
+## Code blocks
+
+```css
+.code-block {
+  background: var(--code-bg);
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius);
+  font-family: var(--font-mono);
+  color: var(--foreground);
+}
+
+/* Syntax tokens */
+.code-block .kw  { color: var(--primary); }
+.code-block .fn  { color: var(--accent); }
+.code-block .str { color: var(--success); }
+.code-block .cm  { color: var(--muted-foreground); font-style: italic; }
+.code-block .num { color: var(--warning); }
+```


### PR DESCRIPTION
Adds a host-neutral **shared Claude-assets layer** parallel to `claude/commands/`, so every hub shares one copy via `rcup`.

## What's added
- **`claude/skills/`** — the 8 `cmux-*` skill packages (`cmux`, `-browser`, `-customization`, `-diagnostics`, `-keyboard-shortcuts`, `-markdown`, `-settings`, `-workspace`). cmux is host-neutral, so these belong in dotfiles and become global (`~/.claude/skills/`).
- **`claude/skills/` (plannotator)** — the 3 plannotator *extra* skills (`plannotator-compound`, `-setup-goal`, `-visual-explainer`), graduated from the work hub's `skills-lock.json` install so both hubs get them globally without the installer tool.
- **`claude/hooks/allow-readonly-traversal.py`** — `PreToolUse(Bash)` hook that auto-approves *provably* read-only `cd`+`/dev/null` submodule traversals (abstains otherwise; keyed to `CLAUDE_PROJECT_DIR`), removing the built-in cd+redirect approval prompt. Genericized from the hub-local copy (host-neutral docstring; `getcwd()` fallback since it now installs at `~/.claude/hooks/`).
- **`claude/WORKSPACE.md`** — documents the new layer + how to add to it (`rcup`).

## Provenance
Graduated from the hub, where these were incubated hub-local. The hub-local copies have been removed there so dotfiles is the single source of truth.

## Wiring (not tracked here)
The hook is wired globally in `~/.claude/settings.json` as a `PreToolUse(Bash)` hook. `rcup` links `claude/{skills,hooks}/` into `~/.claude/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)